### PR TITLE
Fixed broken links and replaced unusual UniProt ID with a valid one.

### DIFF
--- a/src/main/webapp/resources/html/FAQ.html
+++ b/src/main/webapp/resources/html/FAQ.html
@@ -84,7 +84,7 @@
         <p>
             Raw single-channel microarray intensities are normalized using
             <a href="https://biostatistics.oxfordjournals.org/content/4/2/249.long">RMA</a> via the
-            <a href="https://www.bioconductor.org/packages/release/bioc/html/oligo.html">oligo</a> package from
+            <a href="https://doi.org/10.1093/biostatistics/4.2.249">oligo</a> package from
             <a href="https://www.bioconductor.org/">Bioconductor</a> (<a href="https://www.affymetrix.com/">
             Affymetrix</a> data) or using quantile normalization via the
             <a href="https://www.bioconductor.org/packages/release/bioc/html/limma.html">limma</a> package
@@ -259,7 +259,7 @@
             </li>
             <li>
                 <a href="https://www.uniprot.org/">UniProt</a> ID, e.g.
-                <a href="/gxa/genesets/A0A0S2Z4Q0">A0A0S2Z4Q0</a>
+                <a href="/gxa/genesets/O14777">O14777</a>
             </li>
             <li>
                 <a href="https://www.ebi.ac.uk/interpro/">Interpro</a> ID, e.g.
@@ -440,7 +440,7 @@
             mapping resource</a> you can also use the
             <img alt="Gramene Genome Browser" src="/gxa/resources/images/faq/gramene-genome-browser-button.png" align="bottom">
             button to see, for example,
-            <a href="ensembl.gramene.org/Arabidopsis_thaliana/Location/View?g=AT2G27380;r=2:11713411-11715774;t=AT2G27380.1;time=1484746364">
+            <a href="http://ensembl.gramene.org/Arabidopsis_thaliana/Location/View?g=AT2G27380;r=2:11713411-11715774;t=AT2G27380.1;time=1484746364">
             gene expression value for gene EPR1 in ecotype Sf-2 x Can-0 in the context of the genomic location of
             EPR1</a>.
         </p>


### PR DESCRIPTION
Exactly the [same PR](https://github.com/ebi-gene-expression-group/atlas/pull/245) as in the old Atlas repo.