### PR TITLE
Bugfix #166430782 – Show build info in `json/build` endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,16 +125,19 @@ processResources {
 
     filesMatching(['*.properties', '*.xml']) {
         expand(
+                projectBuildDirectory: buildDir,
+                dataFilesLocation: dataFilesLocation,
                 jdbcUrl: jdbcUrl,
                 jdbcUsername: jdbcUsername,
                 jdbcPassword: jdbcPassword,
-                dataFilesLocation: dataFilesLocation,
-                projectBuildDirectory: buildDir,
-                testLogs: testLogs,
                 zkHost: zkHost,
                 zkPort: zkPort,
                 solrHost: solrHost,
                 solrPort: solrPort,
+                testLogs: testLogs,
+                buildNumber: '${buildNumber}',
+                buildBranch: '${buildBranch}',
+                buildRevision: '${buildRevision}',
                 catalinaBase: '${catalina.base}',
                 tomcatHostname: '${tomcat.hostname}'
         )
@@ -149,16 +152,21 @@ processTestResources {
 
     filesMatching(['*.properties', '*.xml']) {
         expand(
+                projectBuildDirectory: buildDir,
+                dataFilesLocation: dataFilesLocation,
                 jdbcUrl: jdbcUrl,
                 jdbcUsername: jdbcUsername,
                 jdbcPassword: jdbcPassword,
-                dataFilesLocation: dataFilesLocation,
-                projectBuildDirectory: buildDir,
-                testLogs: testLogs,
                 zkHost: zkHost,
                 zkPort: zkPort,
                 solrHost: solrHost,
-                solrPort: solrPort
+                solrPort: solrPort,
+                testLogs: testLogs,
+                buildNumber: '${buildNumber}',
+                buildBranch: '${buildBranch}',
+                buildRevision: '${buildRevision}',
+                catalinaBase: '${catalina.base}',
+                tomcatHostname: '${tomcat.hostname}'
         )
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/monitoring/HealthCheckController.java
+++ b/src/main/java/uk/ac/ebi/atlas/monitoring/HealthCheckController.java
@@ -1,35 +1,30 @@
 package uk.ac.ebi.atlas.monitoring;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ebi.atlas.experimentimport.GxaExperimentDao;
-
-import javax.inject.Inject;
 
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
 @RestController
-public final class HealthCheckController {
+public class HealthCheckController {
+    private final HealthChecker healthChecker;
 
-    private HealthCheckService healthCheckService;
-    private GxaExperimentDao experimentDao;
-
-    @Inject
     public HealthCheckController(HealthCheckService healthCheckService, GxaExperimentDao experimentDao) {
-        this.healthCheckService = healthCheckService;
-        this.experimentDao = experimentDao;
+        healthChecker = new HealthChecker(
+                healthCheckService,
+                experimentDao,
+                ImmutableSet.of("bioentities"),
+                ImmutableSet.of("bulk-analytics"));
     }
 
-    @GetMapping(value = "/json/health",
-                produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @RequestMapping(value = "/json/health",
+                    method = RequestMethod.GET,
+                    produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public String getHealthStatus() {
-        return GSON.toJson(ImmutableMap.of(
-                "solr",
-                healthCheckService.isSolrUp(ImmutableList.of("bioentities"), "bulk-analytics") ? "UP" : "DOWN",
-                "db",
-                healthCheckService.isDatabaseUp(experimentDao) ? "UP" : "DOWN"));
+        return GSON.toJson(healthChecker.getHealthStatus());
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/monitoring/JsonBuildVersionController.java
+++ b/src/main/java/uk/ac/ebi/atlas/monitoring/JsonBuildVersionController.java
@@ -16,34 +16,23 @@ import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 @RestController
 @PropertySource("classpath:configuration.properties")
 public class JsonBuildVersionController extends JsonExceptionHandlingController {
+    private final ImmutableMap<String, String> buildVersion;
 
-    private String buildNumber;
-    private String buildBranch;
-    private String buildCommitId;
-    private String tomcatHostname;
-
-    @Inject
-    public JsonBuildVersionController(@Value("${buildNumber}") String buildNumber,
-                                      @Value("${buildBranch}") String buildBranch,
-                                      @Value("${buildRevision}") String buildCommitId,
-                                      @Value("${tomcatHostname}") String tomcatHostname) {
-        this.buildNumber = buildNumber;
-        this.buildBranch = buildBranch;
-        this.buildCommitId = buildCommitId;
-        this.tomcatHostname = tomcatHostname;
+    public JsonBuildVersionController(@Value("${build.number}") String buildNumber,
+                                      @Value("${build.branch}") String buildBranch,
+                                      @Value("${build.commitId}") String buildCommitId,
+                                      @Value("${build.tomcatHostname}") String tomcatHostname) {
+        buildVersion = ImmutableMap.of(
+                "bambooBuildVersion", buildNumber,
+                "gitBranch", buildBranch,
+                "gitCommitID", buildCommitId,
+                "tomcatHostname", tomcatHostname);
     }
 
-    @RequestMapping(
-            value = "/json/build",
-            method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_JSON_UTF8_VALUE
-    )
+    @RequestMapping(value = "/json/build",
+                    method = RequestMethod.GET,
+                    produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public String getBuildInfo() {
-        return GSON.toJson(
-                ImmutableMap.of(
-                        "bambooBuildVersion", buildNumber,
-                        "gitBranch", buildBranch,
-                        "gitCommitID", buildCommitId,
-                        "tomcatHostname", tomcatHostname));
+        return GSON.toJson(buildVersion);
     }
 }

--- a/src/main/resources/configuration.properties
+++ b/src/main/resources/configuration.properties
@@ -1,3 +1,7 @@
 data.files.location = ${dataFilesLocation}
 experiment.files.location = ${dataFilesLocation}/gxa/
 
+build.number = ${buildNumber}
+build.branch = ${buildBranch}
+build.commitId = ${buildRevision}
+build.tomcatHostname = ${tomcatHostname}


### PR DESCRIPTION
In the previous monolithic repository of EA and SCEA we added an endpoint to display some fields to know which Bamboo build no. and which branch/commit was deployed in testing, production, fallback and public servers.

After the change to Gradle we can’t pass that properties directly to the build (if Gradle can do it I don’t know how), so I’ve added them to `configuration.properties` and then they get replaced with the variable expansion in the resource processing task.

You can change that it works by passing the following VM options to Tomcat:
```-DbuildNumber=dev -DbuildBranch=dev -DbuildRevision=dev -Dtomcat.hostname=local```

With this change we have now full feature-parity with our old repo. :smiley: 

This also uses the changes from https://github.com/ebi-gene-expression-group/atlas-web-core/pull/11.