### PR TITLE
Pass experiment filter dropdowns as props to experiment table

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/tiles/views/experiments.jsp
+++ b/src/main/webapp/WEB-INF/jsp/tiles/views/experiments.jsp
@@ -52,6 +52,10 @@
                         {type: 'search', title: 'array designs', width: 220, dataParam: 'arrayDesignNames',
                             link: 'arrayDesigns', resource: 'https://www.ebi.ac.uk/arrayexpress/arrays', endpoint: ''}
                     ],
+            tableFilters : [
+                {label: `Kingdom`, dataParam: `kingdom`},
+                {label: `Experiment Type`, dataParam: `experimentType`}
+            ],
             species: '${species}',
             enableDownload: false
         }, 'experiments');


### PR DESCRIPTION
Passing experiment table dropdown filters as props from jsp - [related single cell PR](https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/61)