### PR TITLE
Bugfix #169585387 – Fix species counting logic

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/home/HomeController.java
+++ b/src/main/java/uk/ac/ebi/atlas/home/HomeController.java
@@ -7,11 +7,11 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 import uk.ac.ebi.atlas.controllers.HtmlExceptionHandlingController;
 import uk.ac.ebi.atlas.experiments.ExperimentInfoListService;
-import uk.ac.ebi.atlas.species.SpeciesProperties;
-import uk.ac.ebi.atlas.species.SpeciesPropertiesTrader;
+import uk.ac.ebi.atlas.home.species.SpeciesSummaryService;
 import uk.ac.ebi.atlas.utils.ExperimentInfo;
 
 import java.util.Random;
+import java.util.function.Function;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static uk.ac.ebi.atlas.home.AtlasInformationDataType.EFO;
@@ -34,41 +34,26 @@ public class HomeController extends HtmlExceptionHandlingController {
     private static final double EASTER_EGG_PROBABILITY = 0.0001;
     private static final Random RANDOM = new Random();
 
-    private final SpeciesPropertiesTrader speciesPropertiesTrader;
+    private final SpeciesSummaryService speciesSummaryService;
     private final AtlasInformationDao atlasInformationDao;
     private final ExperimentInfoListService experimentInfoListService;
 
-    public HomeController(SpeciesPropertiesTrader speciesPropertiesTrader,
+    public HomeController(SpeciesSummaryService speciesSummaryService,
                           AtlasInformationDao atlasInformationDao,
                           ExperimentInfoListService experimentInfoListService) {
-        this.speciesPropertiesTrader = speciesPropertiesTrader;
+        this.speciesSummaryService = speciesSummaryService;
         this.atlasInformationDao = atlasInformationDao;
         this.experimentInfoListService = experimentInfoListService;
     }
 
     @RequestMapping(value = "/home", produces = "text/html;charset=UTF-8")
     public String getHome(Model model) {
-        model.addAttribute(
-                "separator", RANDOM.nextDouble() < EASTER_EGG_PROBABILITY ? BEST_SEPARATOR : NORMAL_SEPARATOR);
+        var species = speciesSummaryService.getReferenceSpecies()
+                .stream()
+                .collect(toImmutableMap(Function.identity(), StringUtils::capitalize));
 
-        model.addAttribute("topSpecies", S4_SPECIES);
-
-        var allSpecies = speciesPropertiesTrader.getAll().stream()
-                .collect(toImmutableMap(
-                        SpeciesProperties::referenceName,
-                        speciesProperties -> StringUtils.capitalize(speciesProperties.referenceName())));
-        model.addAttribute("species", allSpecies);
-        model.addAttribute("speciesPath", ""); // Required by Spring form tag
-
+        model.addAttribute("numberOfSpecies", species.size());
         model.addAttribute("numberOfStudies", experimentInfoListService.listPublicExperiments().size());
-
-        var numberOfSpecies =
-                experimentInfoListService.listPublicExperiments().stream()
-                        .map(ExperimentInfo::getSpecies)
-                        .distinct()
-                        .count();
-        model.addAttribute("numberOfSpecies", numberOfSpecies);
-
         var numberOfAssays =
                 experimentInfoListService.listPublicExperiments().stream()
                         .mapToInt(ExperimentInfo::getNumberOfAssays)
@@ -80,6 +65,12 @@ public class HomeController extends HtmlExceptionHandlingController {
         model.addAttribute("eg", EG.getId());
         model.addAttribute("wbps", WBPS.getId());
         model.addAttribute("efo", EFO.getId());
+
+        model.addAttribute("topSpecies", S4_SPECIES);
+        model.addAttribute(
+                "separator", RANDOM.nextDouble() < EASTER_EGG_PROBABILITY ? BEST_SEPARATOR : NORMAL_SEPARATOR);
+        model.addAttribute("species", species);
+        model.addAttribute("speciesPath", ""); // Required by Spring form tag
 
         return "home";
     }

--- a/src/main/java/uk/ac/ebi/atlas/home/species/JsonSpeciesSummaryController.java
+++ b/src/main/java/uk/ac/ebi/atlas/home/species/JsonSpeciesSummaryController.java
@@ -22,6 +22,6 @@ public class JsonSpeciesSummaryController extends JsonExceptionHandlingControlle
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public String getSpeciesSummaryGroupedByKingdom() {
         return speciesSummarySerializer.serialize(
-                speciesSummaryService.getSpeciesSummariesGroupedByKingdom());
+                speciesSummaryService.getReferenceSpeciesSummariesGroupedByKingdom());
     }
 }


### PR DESCRIPTION
Use the new method in `SpeciesSummaryService` from https://github.com/ebi-gene-expression-group/atlas-web-core/pull/30 to populate the model in the home controller.