### PR TITLE
Bugfix #171702540 – Species in home dropdown should be sorted alphabetically

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/home/HomeController.java
+++ b/src/main/java/uk/ac/ebi/atlas/home/HomeController.java
@@ -11,10 +11,11 @@ import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.trader.ExperimentTrader;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Random;
 import java.util.function.Function;
 
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSortedMap.toImmutableSortedMap;
 import static uk.ac.ebi.atlas.home.AtlasInformationDataType.EFO;
 import static uk.ac.ebi.atlas.home.AtlasInformationDataType.EG;
 import static uk.ac.ebi.atlas.home.AtlasInformationDataType.ENSEMBL;
@@ -51,7 +52,10 @@ public class HomeController extends HtmlExceptionHandlingController {
     public String getHome(Model model) {
         var species = speciesSummaryService.getReferenceSpecies()
                 .stream()
-                .collect(toImmutableMap(Function.identity(), StringUtils::capitalize));
+                .collect(toImmutableSortedMap(
+                        Comparator.<String>naturalOrder(),
+                        Function.identity(),
+                        StringUtils::capitalize));
 
         model.addAttribute("numberOfSpecies", species.size());
         model.addAttribute("numberOfStudies", experimentTrader.getPublicExperiments().size());

--- a/src/test/java/uk/ac/ebi/atlas/home/HomeControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/home/HomeControllerWIT.java
@@ -1,0 +1,65 @@
+package uk.ac.ebi.atlas.home;
+
+import com.google.common.collect.ImmutableSortedMap;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import uk.ac.ebi.atlas.configuration.TestConfig;
+
+import javax.inject.Inject;
+import javax.sql.DataSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration(classes = TestConfig.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+
+class HomeControllerWIT {
+    @Inject
+    private DataSource dataSource;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    private MockMvc mockMvc;
+
+    @BeforeAll
+    void populateDatabaseTables() {
+        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+        populator.addScripts(new ClassPathResource("fixtures/experiment-fixture.sql"));
+        populator.execute(dataSource);
+    }
+
+    @AfterAll
+    void cleanDatabaseTables() {
+        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+        populator.addScripts(new ClassPathResource("fixtures/experiment-delete.sql"));
+        populator.execute(dataSource);
+    }
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+    }
+
+    @Test
+    void speciesAreSortedAlphabetically() throws Exception {
+        assertThat(mockMvc.perform(get("/home")).andReturn().getModelAndView().getModel().get("species"))
+                .isInstanceOf(ImmutableSortedMap.class);
+    }
+}


### PR DESCRIPTION
Collecting the map to an `ImmutableSortedMap` is enough. The test is a bit weak in the sense that it doesn’t check that it’s actually an `ImmutableSortedMap<String, String>` with `naturalOrder` , but unless we’re doing something very exotic I think it suffices. Eventually we’ll move to a controller like the one we have in Single Cell, and do without the model in favour of a JSON endpoint.