### PR TITLE
Bugfix #171702527 – Web VM host names are leaked to public-facing links

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/home/species/JsonSpeciesSummaryController.java
+++ b/src/main/java/uk/ac/ebi/atlas/home/species/JsonSpeciesSummaryController.java
@@ -17,7 +17,6 @@ public class JsonSpeciesSummaryController extends JsonExceptionHandlingControlle
         this.speciesSummarySerializer = speciesSummarySerializer;
     }
 
-    @Cacheable("speciesSummary")
     @GetMapping(value = "/json/species-summary",
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public String getSpeciesSummaryGroupedByKingdom() {


### PR DESCRIPTION
Disable caching the JSON response and use the cache `speciesSummary` for domain objects in `atlas-web-core`. Otherwise if we access the service via an internal web production VM, the host of that VM (which is part of the `HttpRequest` object and is used in `ServletUriComponentsBuilder.fromCurrentContextPath()`) gets cached as well, and part of the JSON response of the controller.

See also:
* https://github.com/ebi-gene-expression-group/atlas-web-core/pull/45.
* https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/90