### PR TITLE
Rename 'getReferenceSpecies()' to 'getSpecies()'

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/home/HomeController.java
+++ b/src/main/java/uk/ac/ebi/atlas/home/HomeController.java
@@ -50,7 +50,7 @@ public class HomeController extends HtmlExceptionHandlingController {
 
     @RequestMapping(value = "/home", produces = "text/html;charset=UTF-8")
     public String getHome(Model model) {
-        var species = speciesSummaryService.getReferenceSpecies()
+        var species = speciesSummaryService.getSpecies()
                 .stream()
                 .collect(toImmutableSortedMap(
                         Comparator.<String>naturalOrder(),


### PR DESCRIPTION
We have renamed the above method in the core project and missed to update in the bulk. 
we using the above 'getReferenceSpecies()'  method in the HomeController.java. So fixed to remove ugly compilation error. :)