### PR TITLE
Add non functional class for ExperimentCollectionRepository

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentCollection.java
+++ b/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentCollection.java
@@ -1,7 +1,10 @@
 package uk.ac.ebi.atlas.experiments;
 
+import org.springframework.stereotype.Repository;
+
 import java.util.List;
 
+@Repository
 public class ExperimentCollection implements ExperimentCollectionsRepository {
 
     @Override

--- a/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentCollection.java
+++ b/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentCollection.java
@@ -1,0 +1,11 @@
+package uk.ac.ebi.atlas.experiments;
+
+import java.util.List;
+
+public class ExperimentCollection implements ExperimentCollectionsRepository {
+
+    @Override
+    public List<String> getExperimentCollections(String accession) {
+        return List.of(); //ATM this class does nothing as collection table is not implemented in db as yet
+    }
+}

--- a/src/main/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryController.java
+++ b/src/main/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryController.java
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ebi.atlas.controllers.JsonExceptionHandlingController;
+import uk.ac.ebi.atlas.experiments.ExperimentJsonSerializer;
 import uk.ac.ebi.atlas.model.card.CardModel;
 import uk.ac.ebi.atlas.model.card.CardModelAdapter;
 import uk.ac.ebi.atlas.trader.ExperimentTrader;
@@ -36,7 +37,8 @@ public class JsonExperimentsSummaryController extends JsonExceptionHandlingContr
     private final LatestExperimentsService latestExperimentsService;
 
     public JsonExperimentsSummaryController(LatestExperimentsDao latestExperimentsDao,
-                                            ExperimentTrader experimentTrader) {
+                                            ExperimentTrader experimentTrader,
+                                            ExperimentJsonSerializer experimentJsonSerializer) {
         this.latestExperimentsService =
                 new LatestExperimentsService(
                         latestExperimentsDao,
@@ -47,7 +49,8 @@ public class JsonExperimentsSummaryController extends JsonExceptionHandlingContr
                                 MICROARRAY_2COLOUR_MRNA_DIFFERENTIAL,
                                 RNASEQ_MRNA_DIFFERENTIAL,
                                 PROTEOMICS_BASELINE,
-                                RNASEQ_MRNA_BASELINE));
+                                RNASEQ_MRNA_BASELINE),
+                        experimentJsonSerializer);
     }
 
     @GetMapping(value = "/json/experiments-summary",

--- a/src/main/java/uk/ac/ebi/atlas/home/LatestExperimentsService.java
+++ b/src/main/java/uk/ac/ebi/atlas/home/LatestExperimentsService.java
@@ -16,6 +16,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 public class LatestExperimentsService {
     private final LatestExperimentsDao latestExperimentsDao;
     private final ExperimentTrader experimentTrader;
+    private final ExperimentJsonSerializer experimentJsonSerializer;
     private final ImmutableSet<ExperimentType> experimentTypes;
 
     private final LazyReference<ImmutableMap<String, Object>> latestExperimentsAttributes =
@@ -27,7 +28,7 @@ public class LatestExperimentsService {
                         var latestExperimentInfo =
                                 latestExperimentsDao.fetchLatestExperimentAccessions(experimentTypes).stream()
                                         .map(experimentTrader::getPublicExperiment)
-                                        .map(ExperimentJsonSerializer::serialize)
+                                        .map(experimentJsonSerializer::serialize)
                                         .collect(toImmutableSet());
 
                         return ImmutableMap.of(
@@ -40,10 +41,12 @@ public class LatestExperimentsService {
 
     public LatestExperimentsService(LatestExperimentsDao latestExperimentsDao,
                                     ExperimentTrader experimentTrader,
-                                    Set<ExperimentType> experimentTypes) {
+                                    Set<ExperimentType> experimentTypes,
+                                    ExperimentJsonSerializer experimentJsonSerializer) {
         this.latestExperimentsDao = latestExperimentsDao;
         this.experimentTrader = experimentTrader;
         this.experimentTypes = ImmutableSet.copyOf(experimentTypes);
+        this.experimentJsonSerializer = experimentJsonSerializer;
     }
 
     public ImmutableMap<String, Object> fetchLatestExperimentsAttributes() {

--- a/src/test/java/uk/ac/ebi/atlas/configuration/TestConfig.java
+++ b/src/test/java/uk/ac/ebi/atlas/configuration/TestConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.web.client.RestTemplate;
-import uk.ac.ebi.atlas.experiments.ExperimentJsonSerializer;
 
 @Configuration
 // Enabling component scanning will also load BasePathsConfig, JdbcConfig and SolrConfig, so just using this class as
@@ -23,7 +22,4 @@ public class TestConfig {
     public RestTemplate restTemplate() {
         return new RestTemplate();
     }
-
-    @Bean
-    public ExperimentJsonSerializer experimentJsonSerializer() { return null; }
 }

--- a/src/test/java/uk/ac/ebi/atlas/configuration/TestConfig.java
+++ b/src/test/java/uk/ac/ebi/atlas/configuration/TestConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.web.client.RestTemplate;
+import uk.ac.ebi.atlas.experiments.ExperimentJsonSerializer;
 
 @Configuration
 // Enabling component scanning will also load BasePathsConfig, JdbcConfig and SolrConfig, so just using this class as
@@ -22,4 +23,7 @@ public class TestConfig {
     public RestTemplate restTemplate() {
         return new RestTemplate();
     }
+
+    @Bean
+    public ExperimentJsonSerializer experimentJsonSerializer() { return null; }
 }

--- a/src/test/java/uk/ac/ebi/atlas/home/LatestExperimentsServiceIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/home/LatestExperimentsServiceIT.java
@@ -16,6 +16,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 import uk.ac.ebi.atlas.configuration.TestConfig;
+import uk.ac.ebi.atlas.experiments.ExperimentJsonSerializer;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import uk.ac.ebi.atlas.trader.ExperimentTrader;
 
@@ -40,6 +41,9 @@ public class LatestExperimentsServiceIT {
 
     @Inject
     private LatestExperimentsDao latestExperimentsDao;
+
+    @Inject
+    private ExperimentJsonSerializer experimentJsonSerializer;
 
     @Inject
     private DataSource dataSource;
@@ -72,7 +76,8 @@ public class LatestExperimentsServiceIT {
                                 ExperimentType.RNASEQ_MRNA_DIFFERENTIAL,
                                 ExperimentType.PROTEOMICS_BASELINE,
                                 ExperimentType.RNASEQ_MRNA_BASELINE
-                        ));
+                        ),
+                        experimentJsonSerializer);
     }
 
     @Test


### PR DESCRIPTION
As `collections` and `experiment2collection` table is not yet added to bulk db so have to add a non functional class for experiment collections in bulk.

Other code changes are result of changing `ExperimentJsonSerializer` class.

Accompanying web-core PR:
https://github.com/ebi-gene-expression-group/atlas-web-core/pull/52