### PR TITLE
Feature/180083715 rename pdf file for download

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
@@ -227,13 +227,16 @@ public class ExperimentDownloadController {
                                 .add(experimentFileLocationService.getFilePath(
                                         experiment.getAccession(), ExperimentFileType.IDF))
                                 .add(experimentFileLocationService.getFilePath(
-                                        experiment.getAccession(), ExperimentFileType.PROTEOMICS_B_MAIN));
+                                        experiment.getAccession(), ExperimentFileType.PROTEOMICS_B_MAIN))
+                                .add(experimentFileLocationService.getFilePath(
+                                        experiment.getAccession(), ExperimentFileType.SUMMARY_PDF));
                         break;
 
                     case RNASEQ_MRNA_DIFFERENTIAL:
                         paths.add(experimentFileLocationService.getFilePath(
                                 experiment.getAccession(), ExperimentFileType.CONFIGURATION))
                                 .add(experimentFileLocationService.getFilePath(
+
                                         experiment.getAccession(), ExperimentFileType.CONDENSE_SDRF))
                                 .add(experimentFileLocationService.getFilePath(
                                         experiment.getAccession(), ExperimentFileType.IDF))
@@ -304,6 +307,7 @@ public class ExperimentDownloadController {
                     ExperimentFileType.CONFIGURATION,
                     ExperimentFileType.BASELINE_FACTORS,
                     ExperimentFileType.IDF,
+                    ExperimentFileType.SUMMARY_PDF,
                     ExperimentFileType.PROTEOMICS_B_MAIN));
             put(ExperimentType.RNASEQ_MRNA_DIFFERENTIAL, ImmutableList.of(
                     ExperimentFileType.CONDENSE_SDRF,

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
@@ -52,9 +52,11 @@ import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 public class ExperimentDownloadController {
 
     private final ExperimentTrader experimentTrader;
+    //TODO: Proteomics class is only refering to proteomics-baseline, while proteomics-differential will go bulkDifferential class
+    //TODO: Refactor the Proteomics name properly
     private final ExperimentDownloadSupplier.Proteomics proteomicsExperimentDownloadSupplier;
     private final ExperimentDownloadSupplier.RnaSeqBaseline rnaSeqBaselineExperimentDownloadSupplier;
-    private final ExperimentDownloadSupplier.RnaSeqDifferential rnaSeqDifferentialExperimentDownloadSupplier;
+    private final ExperimentDownloadSupplier.BulkDifferential bulkDifferentialExperimentDownloadSupplier;
     private final ExperimentDownloadSupplier.Microarray microarrayExperimentDownloadSupplier;
     private final ExperimentFileLocationService experimentFileLocationService;
 
@@ -66,8 +68,8 @@ public class ExperimentDownloadController {
                                                 proteomicsExperimentDownloadSupplier,
                                         ExperimentDownloadSupplier.RnaSeqBaseline
                                                 rnaSeqBaselineExperimentDownloadSupplier,
-                                        ExperimentDownloadSupplier.RnaSeqDifferential
-                                                rnaSeqDifferentialExperimentDownloadSupplier,
+                                        ExperimentDownloadSupplier.BulkDifferential
+                                                    bulkDifferentialExperimentDownloadSupplier,
                                         ExperimentDownloadSupplier.Microarray
                                                 microarrayExperimentDownloadSupplier,
                                         ExperimentFileLocationService
@@ -75,7 +77,7 @@ public class ExperimentDownloadController {
         this.experimentTrader = experimentTrader;
         this.proteomicsExperimentDownloadSupplier = proteomicsExperimentDownloadSupplier;
         this.rnaSeqBaselineExperimentDownloadSupplier = rnaSeqBaselineExperimentDownloadSupplier;
-        this.rnaSeqDifferentialExperimentDownloadSupplier = rnaSeqDifferentialExperimentDownloadSupplier;
+        this.bulkDifferentialExperimentDownloadSupplier = bulkDifferentialExperimentDownloadSupplier;
         this.microarrayExperimentDownloadSupplier = microarrayExperimentDownloadSupplier;
         this.experimentFileLocationService = experimentFileLocationService;
     }
@@ -144,8 +146,20 @@ public class ExperimentDownloadController {
         DifferentialExperiment experiment =
                 (DifferentialExperiment) experimentTrader.getExperiment(experimentAccession, accessKey);
 
-        rnaSeqDifferentialExperimentDownloadSupplier.write(response, preferences, experiment, "tsv");
+        bulkDifferentialExperimentDownloadSupplier.write(response, preferences, experiment, "tsv");
+    }
 
+    @RequestMapping(value = DOWNLOAD_URL_TEMPLATE, params = "type=PROTEOMICS_DIFFERENTIAL")
+    public void
+    proteomicsDifferentialExperimentDownload(
+            @PathVariable String experimentAccession,
+            @RequestParam(value = "accessKey", required = false) String accessKey,
+            @ModelAttribute("preferences") @Valid DifferentialRequestPreferences preferences,
+            HttpServletResponse response) throws IOException {
+        DifferentialExperiment experiment =
+                (DifferentialExperiment) experimentTrader.getExperiment(experimentAccession, accessKey);
+
+        bulkDifferentialExperimentDownloadSupplier.write(response, preferences, experiment, "tsv");
     }
 
     void microarrayExperimentDownload(String experimentAccession,

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
@@ -241,13 +241,16 @@ public class ExperimentDownloadController {
                                 .add(experimentFileLocationService.getFilePath(
                                         experiment.getAccession(), ExperimentFileType.IDF))
                                 .add(experimentFileLocationService.getFilePath(
-                                        experiment.getAccession(), ExperimentFileType.PROTEOMICS_B_MAIN));
+                                        experiment.getAccession(), ExperimentFileType.PROTEOMICS_B_MAIN))
+                                .add(experimentFileLocationService.getFilePath(
+                                        experiment.getAccession(), ExperimentFileType.SUMMARY_PDF));
                         break;
 
                     case RNASEQ_MRNA_DIFFERENTIAL:
                         paths.add(experimentFileLocationService.getFilePath(
                                 experiment.getAccession(), ExperimentFileType.CONFIGURATION))
                                 .add(experimentFileLocationService.getFilePath(
+
                                         experiment.getAccession(), ExperimentFileType.CONDENSE_SDRF))
                                 .add(experimentFileLocationService.getFilePath(
                                         experiment.getAccession(), ExperimentFileType.IDF))
@@ -318,6 +321,7 @@ public class ExperimentDownloadController {
                     ExperimentFileType.CONFIGURATION,
                     ExperimentFileType.BASELINE_FACTORS,
                     ExperimentFileType.IDF,
+                    ExperimentFileType.SUMMARY_PDF,
                     ExperimentFileType.PROTEOMICS_B_MAIN));
             put(ExperimentType.RNASEQ_MRNA_DIFFERENTIAL, ImmutableList.of(
                     ExperimentFileType.CONDENSE_SDRF,

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentFileLocationService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentFileLocationService.java
@@ -31,6 +31,8 @@ public class ExperimentFileLocationService {
                 return dataFileHub.getProteomicsBaselineExperimentFiles(experimentAccession).experimentFiles.condensedSdrf.getPath();
             case IDF:
                 return dataFileHub.getExperimentFiles(experimentAccession).idf.getPath();
+            case SUMMARY_PDF:
+                return dataFileHub.getExperimentFiles(experimentAccession).summaryPdf.getPath();
             case PROTEOMICS_B_MAIN:
                 return dataFileHub.getProteomicsBaselineExperimentFiles(experimentAccession).main.getPath();
             case BASELINE_FACTORS:

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentFileType.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentFileType.java
@@ -8,6 +8,8 @@ public enum ExperimentFileType {
     // Could include icon name (similar to Description class in ExternallyAvailableContent)
     CONFIGURATION(
             "configuration", "Experiment configuration file (XML format)", IconType.EXPERIMENT_DESIGN, false),
+    SUMMARY_PDF(
+            "summary pdf", "PRIDE summary file (PDF format)", IconType.EXPERIMENT_DESIGN, false),
     IDF(
             "idf", "IDF file (TSV format)", IconType.TSV, false),
     CONDENSE_SDRF(

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExpressionAtlasContentService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExpressionAtlasContentService.java
@@ -55,7 +55,7 @@ public class ExpressionAtlasContentService {
     public ExpressionAtlasContentService(
             ExperimentDownloadSupplier.Proteomics proteomicsExperimentDownloadSupplier,
             ExperimentDownloadSupplier.RnaSeqBaseline rnaSeqBaselineExperimentDownloadSupplier,
-            ExperimentDownloadSupplier.RnaSeqDifferential rnaSeqDifferentialExperimentDownloadSupplier,
+            ExperimentDownloadSupplier.BulkDifferential bulkDifferential,
             ExperimentDownloadSupplier.Microarray microarrayExperimentDownloadSupplier,
             ContrastImageSupplier.RnaSeq rnaSeqDifferentialContrastImageSupplier,
             ContrastImageSupplier.Microarray microarrayContrastImageSupplier,
@@ -105,7 +105,7 @@ public class ExpressionAtlasContentService {
         this.rnaSeqDifferentialExperimentExternallyAvailableContentService =
                 new ExternallyAvailableContentService<>(
                         ImmutableList.of(
-                                rnaSeqDifferentialExperimentDownloadSupplier,
+                                bulkDifferential,
                                 rnaSeqDifferentialSecondaryDataFiles,
                                 rnaSeqDifferentialStaticFilesDownload,
                                 rnaSeqDifferentialExperimentDesignFile,
@@ -196,6 +196,7 @@ public class ExpressionAtlasContentService {
                 arrayExpressAndOtherExternalResourcesLinks.addAll(otherExternalResourceLinks.build());
                 break;
             case RNASEQ_MRNA_DIFFERENTIAL:
+            case PROTEOMICS_DIFFERENTIAL:
                 arrayExpressAndOtherExternalResourcesLinks.addAll(rnaSeqDifferentialExperimentExternallyAvailableContentService.list(
                         (DifferentialExperiment) experiment, contentType));
                 otherExternalResourceLinks.addAll(externalResourceType.equals("geo") ?

--- a/app/src/main/java/uk/ac/ebi/atlas/trader/GxaExperimentRepository.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/trader/GxaExperimentRepository.java
@@ -11,6 +11,7 @@ import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.trader.factory.BaselineExperimentFactory;
 import uk.ac.ebi.atlas.trader.factory.MicroarrayExperimentFactory;
+import uk.ac.ebi.atlas.trader.factory.ProteomicsDifferentialExperimentFactory;
 import uk.ac.ebi.atlas.trader.factory.RnaSeqDifferentialExperimentFactory;
 
 @Repository
@@ -23,19 +24,22 @@ public class GxaExperimentRepository implements ExperimentRepository {
     private final BaselineExperimentFactory baselineExperimentFactory;
     private final RnaSeqDifferentialExperimentFactory rnaSeqDifferentialExperimentFactory;
     private final MicroarrayExperimentFactory microarrayExperimentFactory;
+    private final ProteomicsDifferentialExperimentFactory proteomicsDifferentialExperimentFactory;
 
     public GxaExperimentRepository(ExperimentCrudDao experimentCrudDao,
                                    ExperimentDesignParser experimentDesignParser,
                                    IdfParser idfParser,
                                    BaselineExperimentFactory baselineExperimentFactory,
                                    RnaSeqDifferentialExperimentFactory rnaSeqDifferentialExperimentFactory,
-                                   MicroarrayExperimentFactory microarrayExperimentFactory) {
+                                   MicroarrayExperimentFactory microarrayExperimentFactory,
+                                   ProteomicsDifferentialExperimentFactory proteomicsDifferentialExperimentFactory) {
         this.experimentCrudDao = experimentCrudDao;
         this.experimentDesignParser = experimentDesignParser;
         this.idfParser = idfParser;
         this.baselineExperimentFactory = baselineExperimentFactory;
         this.rnaSeqDifferentialExperimentFactory = rnaSeqDifferentialExperimentFactory;
         this.microarrayExperimentFactory = microarrayExperimentFactory;
+        this.proteomicsDifferentialExperimentFactory = proteomicsDifferentialExperimentFactory;
     }
 
     @Override
@@ -89,6 +93,12 @@ public class GxaExperimentRepository implements ExperimentRepository {
                         experimentDesign,
                         idfParserOutput,
                         ImmutableSet.of("Microarray 2-colour mRNA"));
+            case PROTEOMICS_DIFFERENTIAL:
+                return proteomicsDifferentialExperimentFactory.create(
+                        experimentDto,
+                        experimentDesign,
+                        idfParserOutput,
+                        ImmutableSet.of("Proteomics differential"));
             default:
                 throw new IllegalArgumentException(
                         "Unable to build experiment " + experimentDto.getExperimentAccession()

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/FileDownloadControllerTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/FileDownloadControllerTest.java
@@ -47,11 +47,10 @@ public class FileDownloadControllerTest {
     private ExperimentDownloadSupplier.RnaSeqBaseline rnaSeqBaselineExperimentDownloadSupplier;
 
     @Mock
-    private ExperimentDownloadSupplier.RnaSeqDifferential rnaSeqDifferentialExperimentDownloadSupplier;
+    private ExperimentDownloadSupplier.BulkDifferential bulkDifferentialExperimentDownloadSupplier;
 
     @Mock
     private ExperimentDownloadSupplier.Microarray microarrayExperimentDownloadSupplier;
-
 
     private ExperimentDownloadController subject;
 
@@ -61,7 +60,7 @@ public class FileDownloadControllerTest {
                 experimentTraderMock,
                 proteomicsExperimentDownloadSupplier,
                 rnaSeqBaselineExperimentDownloadSupplier,
-                rnaSeqDifferentialExperimentDownloadSupplier,
+                bulkDifferentialExperimentDownloadSupplier,
                 microarrayExperimentDownloadSupplier,
                 experimentFileLocationServiceMock);
     }

--- a/app/src/test/java/uk/ac/ebi/atlas/trader/GxaExperimentRepositoryIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/trader/GxaExperimentRepositoryIT.java
@@ -20,12 +20,7 @@ import javax.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_1COLOUR_MICRORNA_DIFFERENTIAL;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_2COLOUR_MRNA_DIFFERENTIAL;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.PROTEOMICS_BASELINE;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.RNASEQ_MRNA_BASELINE;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.RNASEQ_MRNA_DIFFERENTIAL;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.*;
 import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomExperimentAccession;
 
 @ExtendWith(SpringExtension.class)
@@ -68,6 +63,13 @@ class GxaExperimentRepositoryIT {
     @Test
     void differentialRnaSeqExperiments() {
         assertThat(subject.getExperiment(jdbcUtils.fetchRandomExperimentAccession(RNASEQ_MRNA_DIFFERENTIAL)))
+                .isInstanceOf(DifferentialExperiment.class)
+                .hasNoNullFieldsOrProperties();
+    }
+
+    @Test
+    void differentialProteomicsExperiments() {
+        assertThat(subject.getExperiment(jdbcUtils.fetchRandomExperimentAccession(PROTEOMICS_DIFFERENTIAL)))
                 .isInstanceOf(DifferentialExperiment.class)
                 .hasNoNullFieldsOrProperties();
     }

--- a/app/src/test/java/uk/ac/ebi/atlas/trader/GxaExperimentRepositoryTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/trader/GxaExperimentRepositoryTest.java
@@ -14,6 +14,7 @@ import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.trader.factory.BaselineExperimentFactory;
 import uk.ac.ebi.atlas.trader.factory.MicroarrayExperimentFactory;
+import uk.ac.ebi.atlas.trader.factory.ProteomicsDifferentialExperimentFactory;
 import uk.ac.ebi.atlas.trader.factory.RnaSeqDifferentialExperimentFactory;
 
 import java.sql.Timestamp;
@@ -53,6 +54,9 @@ class GxaExperimentRepositoryTest {
     @Mock
     private MicroarrayExperimentFactory microarrayExperimentFactoryMock;
 
+    @Mock
+    private ProteomicsDifferentialExperimentFactory proteomicsDifferentialExperimentFactoryMock;
+
     private GxaExperimentRepository subject;
 
     @BeforeEach
@@ -64,7 +68,8 @@ class GxaExperimentRepositoryTest {
                         idfParserMock,
                         baselineExperimentFactoryMock,
                         rnaSeqDifferentialExperimentFactoryMock,
-                        microarrayExperimentFactoryMock);
+                        microarrayExperimentFactoryMock,
+                        proteomicsDifferentialExperimentFactoryMock);
     }
 
     @Test


### PR DESCRIPTION
Please be aware that this PR will also include the commits that were missing in the implementation of add pdf summary file.

This story is to add summary pdf file into experiment download section.

The filenames could be: `E-PROT-59-Summary_ExpressionAtlas.pdf` or `E-PROT-63-MaxQuant_Summary_ExpressionAtlas.pdf`

