### PR TITLE
Avoid parallel in cli exp design update

### DIFF
--- a/cli/src/main/java/uk/ac/ebi/atlas/cli/experimentDesign/ExperimentDesignCommand.java
+++ b/cli/src/main/java/uk/ac/ebi/atlas/cli/experimentDesign/ExperimentDesignCommand.java
@@ -31,7 +31,6 @@ public class ExperimentDesignCommand implements Callable<Integer> {
 
         LOGGER.info("Starting update experiment designs for accessions.");
         experimentAccessions.stream()
-                .parallel()
                 .forEach(accession -> experimentCrud.updateExperimentDesign(accession));
 
         return 0;


### PR DESCRIPTION
This PR avoid the parallel execution of experiment design updates due to a `XMLReader` class used at some point of the run time is not thread-safe.