### PR TITLE
Correct icon types names to use <i> element

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/IconType.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/IconType.java
@@ -1,10 +1,10 @@
 package uk.ac.ebi.atlas.experimentpage;
 
 public enum IconType {
-    PDF("icon-pdf"),
+    PDF("icon-PDF"),
     TSV("icon-tsv"),
-    XML("icon-xml"),
-    TXT("icon-txt"),
+    XML("icon-XML"),
+    TXT("icon-TXT"),
     ARRAY_EXPRESS("icon-ae"),
     GEO("icon-geo"),
     ENA("icon-ena"),


### PR DESCRIPTION
Due to the changes in the front-end component, we will use the <i> element provided by EBI group for PDF, TXT, and XML file icons. We change the variable name into the same as element classnames.