### PR TITLE
Complete experiment types on different locations

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/controllers/page/BaselineExperimentsController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/controllers/page/BaselineExperimentsController.java
@@ -55,7 +55,7 @@ public class BaselineExperimentsController extends HtmlExceptionHandlingControll
 
         var publicBaselineExperiments =
                 experimentTrader.getPublicExperiments(
-                        ExperimentType.RNASEQ_MRNA_BASELINE, ExperimentType.PROTEOMICS_BASELINE);
+                        ExperimentType.RNASEQ_MRNA_BASELINE, ExperimentType.PROTEOMICS_BASELINE, ExperimentType.PROTEOMICS_BASELINE_DIA);
 
         for (var experiment : publicBaselineExperiments) {
             experimentDisplayNames.put(

--- a/app/src/main/java/uk/ac/ebi/atlas/ebeyedump/ExperimentsConditionsDetailsController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/ebeyedump/ExperimentsConditionsDetailsController.java
@@ -15,12 +15,7 @@ import java.io.UncheckedIOException;
 import java.util.function.Function;
 
 import static java.lang.String.join;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_1COLOUR_MICRORNA_DIFFERENTIAL;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_2COLOUR_MRNA_DIFFERENTIAL;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.PROTEOMICS_BASELINE;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.RNASEQ_MRNA_BASELINE;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.RNASEQ_MRNA_DIFFERENTIAL;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.*;
 
 @Controller
 @Scope("request")
@@ -37,7 +32,7 @@ public class ExperimentsConditionsDetailsController {
                 response,
                 experiment -> new BaselineExperimentAssayGroupsLines((BaselineExperiment) experiment),
                 RNASEQ_MRNA_BASELINE,
-                PROTEOMICS_BASELINE);
+                PROTEOMICS_BASELINE, PROTEOMICS_BASELINE_DIA);
     }
 
     @GetMapping("/api/contrastdetails.tsv")

--- a/app/src/main/java/uk/ac/ebi/atlas/ebeyedump/ExperimentsConditionsDetailsController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/ebeyedump/ExperimentsConditionsDetailsController.java
@@ -15,7 +15,13 @@ import java.io.UncheckedIOException;
 import java.util.function.Function;
 
 import static java.lang.String.join;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.*;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_1COLOUR_MICRORNA_DIFFERENTIAL;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_2COLOUR_MRNA_DIFFERENTIAL;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.PROTEOMICS_BASELINE;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.PROTEOMICS_BASELINE_DIA;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.RNASEQ_MRNA_BASELINE;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.RNASEQ_MRNA_DIFFERENTIAL;
 
 @Controller
 @Scope("request")
@@ -32,7 +38,8 @@ public class ExperimentsConditionsDetailsController {
                 response,
                 experiment -> new BaselineExperimentAssayGroupsLines((BaselineExperiment) experiment),
                 RNASEQ_MRNA_BASELINE,
-                PROTEOMICS_BASELINE, PROTEOMICS_BASELINE_DIA);
+                PROTEOMICS_BASELINE,
+                PROTEOMICS_BASELINE_DIA);
     }
 
     @GetMapping("/api/contrastdetails.tsv")

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
@@ -241,6 +241,7 @@ public class ExperimentDownloadController {
                 var experimentType = experiment.getType();
                 var paths = ImmutableList.<Path>builder();
                 switch (experimentType) {
+                    // do we lack here a proteomics differential case?
                     case PROTEOMICS_BASELINE:
                         paths.add(experimentFileLocationService.getFilePath(
                                 experiment.getAccession(), ExperimentFileType.CONDENSE_SDRF))

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
@@ -241,7 +241,10 @@ public class ExperimentDownloadController {
                 var experimentType = experiment.getType();
                 var paths = ImmutableList.<Path>builder();
                 switch (experimentType) {
-                    // do we lack here a proteomics differential case?
+                    /*
+                       There is another RequestMapping for proteomicsDifferentialExperimentDownload
+                       so no need to have one here.
+                     */
                     case PROTEOMICS_BASELINE:
                         paths.add(experimentFileLocationService.getFilePath(
                                 experiment.getAccession(), ExperimentFileType.CONDENSE_SDRF))

--- a/app/src/main/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryController.java
@@ -17,7 +17,13 @@ import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static uk.ac.ebi.atlas.model.card.CardIconType.IMAGE;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.*;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_1COLOUR_MICRORNA_DIFFERENTIAL;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_2COLOUR_MRNA_DIFFERENTIAL;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.PROTEOMICS_BASELINE;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.PROTEOMICS_BASELINE_DIA;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.RNASEQ_MRNA_BASELINE;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.RNASEQ_MRNA_DIFFERENTIAL;
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 import static uk.ac.ebi.atlas.utils.UrlHelpers.getCustomUrl;
 import static uk.ac.ebi.atlas.utils.UrlHelpers.getExperimentLink;

--- a/app/src/main/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryController.java
@@ -17,12 +17,7 @@ import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static uk.ac.ebi.atlas.model.card.CardIconType.IMAGE;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_1COLOUR_MICRORNA_DIFFERENTIAL;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.MICROARRAY_2COLOUR_MRNA_DIFFERENTIAL;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.PROTEOMICS_BASELINE;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.RNASEQ_MRNA_BASELINE;
-import static uk.ac.ebi.atlas.model.experiment.ExperimentType.RNASEQ_MRNA_DIFFERENTIAL;
+import static uk.ac.ebi.atlas.model.experiment.ExperimentType.*;
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 import static uk.ac.ebi.atlas.utils.UrlHelpers.getCustomUrl;
 import static uk.ac.ebi.atlas.utils.UrlHelpers.getExperimentLink;
@@ -49,6 +44,7 @@ public class JsonExperimentsSummaryController extends JsonExceptionHandlingContr
                                 MICROARRAY_2COLOUR_MRNA_DIFFERENTIAL,
                                 RNASEQ_MRNA_DIFFERENTIAL,
                                 PROTEOMICS_BASELINE,
+                                PROTEOMICS_BASELINE_DIA,
                                 RNASEQ_MRNA_BASELINE),
                         experimentJsonSerializer);
     }

--- a/app/src/main/java/uk/ac/ebi/atlas/solr/analytics/differential/DifferentialFacetsReader.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/solr/analytics/differential/DifferentialFacetsReader.java
@@ -44,6 +44,7 @@ public class DifferentialFacetsReader {
                 .put("rnaseq_mrna_baseline", "RNA-seq mRNA baseline")
                 .put("rnaseq_mrna_differential", "RNA-seq mRNA differential")
                 .put("proteomics_baseline", "proteomics baseline")
+                .put("proteomics_baseline_dia", "proteomics baseline") // assuming this is just the label to show.
                 .put("microarray_1colour_microrna_differential", "Microarray 1-colour microRNA differential")
                 .put("microarray_1colour_mrna_differential", "Microarray 1-colour mRNA differential")
                 .put("microarray_2colour_mrna_differential", "Microarray 2-colour mRNA differential")

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadControllerIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadControllerIT.java
@@ -503,6 +503,7 @@ class ExperimentDownloadControllerIT {
         return Stream.of(jdbcUtils.fetchRandomExperimentAccession(RNASEQ_MRNA_BASELINE));
     }
 
+    // I guess there is no need to add a baseline dia here since none of these methods seem in use.
     private Stream<String> proteomicsBaselineExperimentAccessionProvider() {
         return Stream.of(jdbcUtils.fetchRandomExperimentAccession(PROTEOMICS_BASELINE));
     }


### PR DESCRIPTION
Looking for how to set the bioentities collection name, I run into a few places where I suspect the new proteomics experiment types (baseline_dia and differential) might need to be added. If these findings are all unneeded or irrelevant, please feel free to ignore and close this.

Companion to https://github.com/ebi-gene-expression-group/atlas-web-core/pull/92