### PR TITLE
Bugfix #178882857 – Friendlier Solr errors

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/baseline/topgenes/BaselineExperimentTopGenesService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/baseline/topgenes/BaselineExperimentTopGenesService.java
@@ -37,6 +37,8 @@ public class BaselineExperimentTopGenesService {
                      baselineExperimentTopGenesDao.aggregateGeneIdsAndSortBySpecificity(
                              experimentAccession, preferences)) {
             return mapBySpecifictyAndSortByAverageExpression(tupleStreamer.get(), preferences.getHeatmapMatrixSize());
+        } catch (Exception e) {
+            throw new RuntimeException("The Expression Atlas Solr server could not be reached.");
         }
     }
 
@@ -48,6 +50,8 @@ public class BaselineExperimentTopGenesService {
             return tupleStreamer.get()
                     .map(tuple -> tuple.getString(GENE_KEY))
                     .collect(toList());
+        } catch (Exception e) {
+            throw new RuntimeException("The Expression Atlas Solr server could not be reached.");
         }
     }
 


### PR DESCRIPTION
Nothing worthy of note, just check the wording is ok and that the message is displayed as intended. You can check it by stopping one or all of the SolrCloud containers when the web app is running.

See also https://github.com/ebi-gene-expression-group/atlas-web-core/pull/97.