### PR TITLE
Remove FTP tar ball link

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/download/DownloadController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/download/DownloadController.java
@@ -1,66 +1,17 @@
 package uk.ac.ebi.atlas.download;
 
-import org.apache.commons.net.ftp.FTPFile;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import uk.ac.ebi.atlas.controllers.HtmlExceptionHandlingController;
-
-import org.apache.commons.net.ftp.FTPClient;
-
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.HashMap;
-import java.util.Map;
 
 @Controller
 public class DownloadController extends HtmlExceptionHandlingController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DownloadController.class);
-    private static final String FILEPATH = "/pub/databases/microarray/data/atlas/experiments/atlas-latest-data.tar.gz";
-
     @RequestMapping(value = "/download", produces = "text/html;charset=UTF-8")
-    public String getExperimentsListParameters(@RequestParam(defaultValue = "ftp.ebi.ac.uk", required = false) String ftpHost,
-                                               Model model) {
-        Map<String, String> fileInfo = getFtpFileInfo(ftpHost);
-
-        model.addAttribute("fileSize", fileInfo.get("fileSize"));
-        model.addAttribute("fileName", fileInfo.get("fileName"));
-        model.addAttribute("fileTimestamp", fileInfo.get("fileTimestamp"));
-
+    public String getExperimentsListParameters(Model model) {
         model.addAttribute("mainTitle", "Download ");
 
         return "download";
-    }
-
-    private Map<String, String> getFtpFileInfo(String ftpHost) {
-        Map<String, String> fileInfo = new HashMap<>();
-        FTPClient ftpClient = new FTPClient();
-        try {
-            ftpClient.connect(ftpHost);
-            ftpClient.login("ftp", "anonymous");
-            ftpClient.enterLocalPassiveMode();
-            FTPFile[] file = ftpClient.listFiles(FILEPATH);
-            fileInfo.put("fileName", file[0].getName());
-            fileInfo.put("fileSize", format(file[0].getSize(), 1));
-            fileInfo.put("fileTimestamp", LocalDate.ofInstant(
-                    file[0].getTimestamp().getTime().toInstant(),
-                    ZoneId.systemDefault()).toString());
-        } catch (IOException e) {
-            LOGGER.error(e.getMessage(), e);
-        }
-        return fileInfo;
-    }
-
-    private String format(final double bytes, final int digits) {
-        String[] dictionary = {"bytes", "KiB", "MiB", "GiB", "TiB", "PiB"};
-        final var base = 1024;
-        Double index = Math.floor(Math.log(bytes) / Math.log(base));
-        var size = bytes / Math.pow(base, index);
-        return String.format("%." + digits + "f", size) + " " + dictionary[index.intValue()];
     }
 }

--- a/app/src/main/webapp/WEB-INF/jsp/tiles/views/download.jsp
+++ b/app/src/main/webapp/WEB-INF/jsp/tiles/views/download.jsp
@@ -1,35 +1,14 @@
-<%--@elvariable id="fileName" type="java.lang.String"--%>
-<%--@elvariable id="fileTimestamp" type="java.lang.String"--%>
-<%--@elvariable id="fileSize" type="java.lang.String"--%>
-
 <%@ page pageEncoding="UTF-8" contentType="text/html;charset=UTF-8" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
 <div class="row">
     <div class="12 columns">
         <h2>Download</h2>
-
-        <c:if test="${!empty fileName}">
         <h3>Via FTP</h3>
-        <table style="border: 1px #cdd4d2 solid;">
-            <thead>
-            <tr style="background-color: #E1EEE9">
-                <th style="border: 1px #cdd4d2 solid; padding: 0.5em 1em; text-align: center; background-color: #E1EEE9;">File</th>
-                <th style="border: 1px #cdd4d2 solid; text-align: center; background-color: #E1EEE9;">Description</th>
-                <th style="border: 1px #cdd4d2 solid; text-align: center; background-color: #E1EEE9;">Date</th>
-                <th style="border: 1px #cdd4d2 solid; text-align: center; background-color: #E1EEE9;">Size</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td style="text-align: center; border: 1px #cdd4d2 solid;"><a href="ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/experiments/atlas-latest-data.tar.gz"><pre>${fileName}</pre></a></td>
-                <td style="text-align: center; border: 1px #cdd4d2 solid;">gzipped tar archive of all Expression Atlas analysis results</td>
-                <td style="text-align: center; border: 1px #cdd4d2 solid;">${fileTimestamp}</td>
-                <td style="text-align: center; border: 1px #cdd4d2 solid;">${fileSize}</td>
-            </tr>
-            </tbody>
-        </table>
-        </c:if>
+        <p>
+            You can download data for every dataset individually in Expression Atlas through our
+            <a href="http://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/experiments/" target="_blank">FTP site</a>.
+        </p>
 
         <h3>From experiment pages</h3>
         <p>


### PR DESCRIPTION
Removed FTP file tarball link to replace it with general instructions. This is how the download page looks like:

![Screenshot 2022-02-14 at 13 38 56](https://user-images.githubusercontent.com/13108541/153890031-e18ac817-646d-483c-8463-94b35b6d3390.png)
