### PR TITLE
Aliases and collections need to be passed separately.

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/monitoring/HealthCheckController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/monitoring/HealthCheckController.java
@@ -15,8 +15,8 @@ public class HealthCheckController {
     public HealthCheckController(HealthCheckService healthCheckService) {
         healthChecker = new HealthChecker(
                 healthCheckService,
-                ImmutableSet.of("atlas-bioentities"),
-                ImmutableSet.of("bulk-analytics"));
+                ImmutableSet.of(), // still needs to receive a collection of 'solr collections'
+                ImmutableSet.of("bulk-analytics", "atlas-bioentities")); // collectio of 'solr aliases'
     }
 
     @RequestMapping(value = "/json/health",

--- a/app/src/main/java/uk/ac/ebi/atlas/monitoring/HealthCheckController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/monitoring/HealthCheckController.java
@@ -16,7 +16,7 @@ public class HealthCheckController {
         healthChecker = new HealthChecker(
                 healthCheckService,
                 ImmutableSet.of(), // still needs to receive a collection of 'solr collections'
-                ImmutableSet.of("bulk-analytics", "atlas-bioentities")); // collectio of 'solr aliases'
+                ImmutableSet.of("bulk-analytics", "atlas-bioentities")); // collection of 'solr aliases'
     }
 
     @RequestMapping(value = "/json/health",


### PR DESCRIPTION
Currently the new alias for atlas-bioentities was being passed as part of the 'solr collections' java collection, it needs to be passed in the second java collections argument reserved for 'solr aliases'. This should fix the health endpoint.