### PR TITLE
Add missing check for Proteomics Differential experiment

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
@@ -241,10 +241,6 @@ public class ExperimentDownloadController {
                 var experimentType = experiment.getType();
                 var paths = ImmutableList.<Path>builder();
                 switch (experimentType) {
-                    /*
-                       There is another RequestMapping for proteomicsDifferentialExperimentDownload
-                       so no need to have one here.
-                     */
                     case PROTEOMICS_BASELINE:
                         paths.add(experimentFileLocationService.getFilePath(
                                 experiment.getAccession(), ExperimentFileType.CONDENSE_SDRF))
@@ -256,6 +252,19 @@ public class ExperimentDownloadController {
                                         experiment.getAccession(), ExperimentFileType.IDF))
                                 .add(experimentFileLocationService.getFilePath(
                                         experiment.getAccession(), ExperimentFileType.PROTEOMICS_B_MAIN))
+                                .add(experimentFileLocationService.getFilePath(
+                                        experiment.getAccession(), ExperimentFileType.SUMMARY_PDF));
+                        break;
+
+                    case PROTEOMICS_DIFFERENTIAL:
+                        paths.add(experimentFileLocationService.getFilePath(
+                                experiment.getAccession(), ExperimentFileType.CONDENSE_SDRF))
+                                .add(experimentFileLocationService.getFilePath(
+                                        experiment.getAccession(), ExperimentFileType.CONFIGURATION))
+                                .add(experimentFileLocationService.getFilePath(
+                                        experiment.getAccession(), ExperimentFileType.PROTEOMICS_RAW_QUANT))
+                                .add(experimentFileLocationService.getFilePath(
+                                        experiment.getAccession(), ExperimentFileType.IDF))
                                 .add(experimentFileLocationService.getFilePath(
                                         experiment.getAccession(), ExperimentFileType.SUMMARY_PDF));
                         break;
@@ -350,6 +359,12 @@ public class ExperimentDownloadController {
                     ExperimentFileType.IDF,
                     ExperimentFileType.SUMMARY_PDF,
                     ExperimentFileType.PROTEOMICS_B_MAIN));
+            put(ExperimentType.PROTEOMICS_DIFFERENTIAL, ImmutableList.of(
+                    ExperimentFileType.CONDENSE_SDRF,
+                    ExperimentFileType.CONFIGURATION,
+                    ExperimentFileType.PROTEOMICS_RAW_QUANT,
+                    ExperimentFileType.IDF,
+                    ExperimentFileType.SUMMARY_PDF));
             put(ExperimentType.RNASEQ_MRNA_DIFFERENTIAL, ImmutableList.of(
                     ExperimentFileType.CONDENSE_SDRF,
                     ExperimentFileType.CONFIGURATION,

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
@@ -266,6 +266,8 @@ public class ExperimentDownloadController {
                                 .add(experimentFileLocationService.getFilePath(
                                         experiment.getAccession(), ExperimentFileType.IDF))
                                 .add(experimentFileLocationService.getFilePath(
+                                        experiment.getAccession(), ExperimentFileType.RNASEQ_D_ANALYTICS))
+                                .add(experimentFileLocationService.getFilePath(
                                         experiment.getAccession(), ExperimentFileType.SUMMARY_PDF));
                         break;
 

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
@@ -365,6 +365,7 @@ public class ExperimentDownloadController {
                     ExperimentFileType.CONDENSE_SDRF,
                     ExperimentFileType.CONFIGURATION,
                     ExperimentFileType.PROTEOMICS_RAW_QUANT,
+                    ExperimentFileType.RNASEQ_D_ANALYTICS,
                     ExperimentFileType.IDF,
                     ExperimentFileType.SUMMARY_PDF));
             put(ExperimentType.RNASEQ_MRNA_DIFFERENTIAL, ImmutableList.of(

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadController.java
@@ -266,7 +266,7 @@ public class ExperimentDownloadController {
                                 .add(experimentFileLocationService.getFilePath(
                                         experiment.getAccession(), ExperimentFileType.IDF))
                                 .add(experimentFileLocationService.getFilePath(
-                                        experiment.getAccession(), ExperimentFileType.RNASEQ_D_ANALYTICS))
+                                        experiment.getAccession(), ExperimentFileType.PROTEOMICS_D_ANALYTICS))
                                 .add(experimentFileLocationService.getFilePath(
                                         experiment.getAccession(), ExperimentFileType.SUMMARY_PDF));
                         break;
@@ -365,7 +365,7 @@ public class ExperimentDownloadController {
                     ExperimentFileType.CONDENSE_SDRF,
                     ExperimentFileType.CONFIGURATION,
                     ExperimentFileType.PROTEOMICS_RAW_QUANT,
-                    ExperimentFileType.RNASEQ_D_ANALYTICS,
+                    ExperimentFileType.PROTEOMICS_D_ANALYTICS,
                     ExperimentFileType.IDF,
                     ExperimentFileType.SUMMARY_PDF));
             put(ExperimentType.RNASEQ_MRNA_DIFFERENTIAL, ImmutableList.of(

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentFileLocationService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentFileLocationService.java
@@ -45,6 +45,8 @@ public class ExperimentFileLocationService {
                 return dataFileHub.getRnaSeqBaselineExperimentFiles(experimentAccession).tpms.getPath();
             case RNASEQ_D_ANALYTICS:
                 return dataFileHub.getBulkDifferentialExperimentFiles(experimentAccession).analytics.getPath();
+            case PROTEOMICS_D_ANALYTICS:
+                return dataFileHub.getBulkDifferentialExperimentFiles(experimentAccession).analytics.getPath();
            default:
                 return null;
         }

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentFileType.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentFileType.java
@@ -24,6 +24,8 @@ public enum ExperimentFileType {
             "parameter-file", "Parameter file (XML format)", IconType.XML, false),
     RNASEQ_B_TPM(
             "tpm", "TPM file (TSV format)", IconType.TSV, false),
+    PROTEOMICS_D_ANALYTICS(
+            "proteomics-analytics", "Proteomics differential analytics files (TSV format)", IconType.TSV, false),
     RNASEQ_D_ANALYTICS(
             "rnaseq-analytics", "RNASeq analytics files (TSV format)", IconType.TSV, false),
     MICROARRAY_D_ANALYTICS(

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/ExperimentDownloadControllerWIT.java
@@ -51,7 +51,8 @@ class ExperimentDownloadControllerWIT {
             "E-MTAB-3834", //RNASEQ_MRNA_DIFFERENTIAL
             "E-PROT-1", //PROTEOMICS_BASELINE
             "E-TABM-713",//MICROARRAY_1COLOUR_MICRORNA_DIFFERENTIAL
-            "E-PROT-28"); //PROTEOMICS_BASELINE_DIA
+            "E-PROT-28", //PROTEOMICS_BASELINE_DIA
+            "E-PROT-39"); //PROTEOMICS_DIFFERENTIAL
     private static final List<String> INVALID_EXPERIMENT_ACCESSION_LIST = ImmutableList.of("E-ERAD", "E-GEOD");
     private static final String ARCHIVE_NAME = "{0}-{1}-files.zip";
     private static final String ARCHIVE_DOWNLOAD_LIST_URL = "/experiments/download/zip";
@@ -108,7 +109,8 @@ class ExperimentDownloadControllerWIT {
                 .param("accession", EXPERIMENT_ACCESSION_LIST.get(3))
                 .param("accession", EXPERIMENT_ACCESSION_LIST.get(4))
                 .param("accession", EXPERIMENT_ACCESSION_LIST.get(5))
-                .param("accession", EXPERIMENT_ACCESSION_LIST.get(5))
+                .param("accession", EXPERIMENT_ACCESSION_LIST.get(6))
+                .param("accession", EXPERIMENT_ACCESSION_LIST.get(7))
                 .param("accession", INVALID_EXPERIMENT_ACCESSION_LIST.get(0))
                 .param("accession", INVALID_EXPERIMENT_ACCESSION_LIST.get(1)));
 
@@ -166,6 +168,21 @@ class ExperimentDownloadControllerWIT {
                                 experiment.getAccession(), ExperimentFileType.IDF))
                         .add(experimentFileLocationService.getFilePath(
                                 experiment.getAccession(), ExperimentFileType.RNASEQ_D_ANALYTICS));
+                break;
+
+            case PROTEOMICS_DIFFERENTIAL:
+                paths.add(experimentFileLocationService.getFilePath(
+                        experiment.getAccession(), ExperimentFileType.CONDENSE_SDRF))
+                        .add(experimentFileLocationService.getFilePath(
+                                experiment.getAccession(), ExperimentFileType.CONFIGURATION))
+                        .add(experimentFileLocationService.getFilePath(
+                                experiment.getAccession(), ExperimentFileType.PROTEOMICS_RAW_QUANT))
+                        .add(experimentFileLocationService.getFilePath(
+                                experiment.getAccession(), ExperimentFileType.IDF))
+                        .add(experimentFileLocationService.getFilePath(
+                                experiment.getAccession(), ExperimentFileType.PROTEOMICS_D_ANALYTICS))
+                        .add(experimentFileLocationService.getFilePath(
+                                experiment.getAccession(), ExperimentFileType.SUMMARY_PDF));
                 break;
 
             case RNASEQ_MRNA_BASELINE:


### PR DESCRIPTION
This PR fixes the issue mentioned.[here](https://github.com/ebi-gene-expression-group/atlas-web-bulk/issues/126)

@pcm32 please review if the downloaded files list is correct for the differential proteomics experiment.

@lingyun1010 you mentioned [in this PR](https://github.com/ebi-gene-expression-group/atlas-web-bulk/pull/111/commits/3f78905542299aff0955dac37be62b50eb193fff#r803643658) that we do not need an end point for proteomics differential as there is another endpoint already. The issue here is that the experiment table uses `experiments/download/zip` endpoint to download a zip file and the differential proteomics experiment case is not covered in this endpoint because of which the issue arose. Please review the code and let me know if I'm missing something here.