### PR TITLE
Update publication on license page

### DIFF
--- a/app/src/main/webapp/resources/html/licence.html
+++ b/app/src/main/webapp/resources/html/licence.html
@@ -10,8 +10,8 @@
         </p>
         <cite>
             <p class="icon icon-conceptual" data-icon="l">
-                <a href="https://academic.oup.com/nar/article/48/D1/D77/5609521">Expression Atlas update: from tissues to single cells</a>
-                (<i>Nucleic Acids Research</i>, 30 October 2019).
+                <a href="https://academic.oup.com/nar/article/50/D1/D129/6438036">Expression Atlas update: gene and protein expression in multiple species</a>
+                (<i>Nucleic Acids Research</i>, 24 November 2021).
             </p>
         </cite>
 


### PR DESCRIPTION
A very simple one-liner change to update the publication link on the licence page.