### PR TITLE
Update URL format for auto complete

### DIFF
--- a/app/src/main/webapp/resources/js/conditionAutocompleteModule.js
+++ b/app/src/main/webapp/resources/js/conditionAutocompleteModule.js
@@ -23,12 +23,12 @@ var conditionAutocompleteModule = (function ($) {
             .jsonTagEditor({
                 autocomplete: {
                     plugin: 'arrayExpressAutocomplete',
-                    urlOrData:  'https://www.ebi.ac.uk/arrayexpress/efowords.txt',
+                    urlOrData:  'https://www.ebi.ac.uk/biostudies/api/v1/autocomplete/keywords',
                     matchContains: false,
                     selectFirst: false,
                     scroll: true,
                     max: 50,
-                    requestTreeUrl: 'https://www.ebi.ac.uk/arrayexpress/efotree.txt',
+                    requestTreeUrl: 'https://www.ebi.ac.uk/biostudies/api/v1/autocomplete/efotree',
                     width: 300
                 },
                 onChange: onChange,

--- a/app/src/main/webapp/resources/js/lib/arrayexpress-autocomplete/jquery.array-express.autocomplete-1.1.0.150319.js
+++ b/app/src/main/webapp/resources/js/lib/arrayexpress-autocomplete/jquery.array-express.autocomplete-1.1.0.150319.js
@@ -548,7 +548,7 @@ $.Autocompleter = function(input, options) {
 				dataType: options.dataType,
 				url: options.url,
 				data: $.extend({
-					q: text,
+					query: text,
                     field: field,
 					limit: options.max
 				}, extraParams),


### PR DESCRIPTION
After arrayexpress migrated to biostudies the module we were using for autocomplete was broken. Upon investigating it was found that the URL format has changed so this PR fix that and updates the current URL to match the latest biostudies url.