### PR TITLE
Incorrect link for current NAR paper

### DIFF
--- a/app/src/main/webapp/WEB-INF/jsp/tiles/views/home/publications.jsp
+++ b/app/src/main/webapp/WEB-INF/jsp/tiles/views/home/publications.jsp
@@ -3,7 +3,7 @@
 <div id="publication-list" class="callout" data-equalizer-watch>
     <h4>Publications</h4>
 
-    <a href="https://academic.oup.com/nar/advance-article/doi/10.1093/nar/gkz947/5609521" target="_blank">
+    <a href="https://academic.oup.com/nar/article/50/D1/D129/6438036" target="_blank">
         <div class="media-object">
             <div class="media-object-section middle">
                 <h3 class="icon icon-conceptual" data-icon="l" />


### PR DESCRIPTION
Currently link in publications has wording for newer paper title, but is pointing to older NAR paper. I noticed this in the public facing page of bulk atlas.

I hope that you are all doing well!