### PR TITLE
Use new API of atlas-react-fetch-loader

### DIFF
--- a/app/src/main/javascript/bundles/differential-expression/src/DifferentialResults.js
+++ b/app/src/main/javascript/bundles/differential-expression/src/DifferentialResults.js
@@ -68,16 +68,19 @@ const DifferentialResultsRow = (props) => {
                    onMouseEnter={() => setHover(true)}>
                     {props.comparison}
                 </a>
-                {inHover && <FetchLoaderContrastTooltip
+                {
+                  inHover &&
+                  <FetchLoaderContrastTooltip 
                     id={`${props.id}_contrast`}
                     host={props.atlasUrl}
-                    resource={URI(`rest/contrast-summary`)
-                        .addSearch(`experimentAccession`, props.experimentAccession)
-                        .addSearch(`contrastId`, props.contrastId)
-                        .addSearch(`accessKey`, props.accessKey)
-                        .toString()}
+                    resource={URI(`rest/contrast-summary`)}
+                    query={{
+                      experimentAccession: props.experimentAccession,
+                      contrastId: props.contrastId,
+                      accessKey: props.accessKey
+                    }}
                     fulfilledPayloadProvider={data => ({result: data})}
-                />
+                  />
                 }
             </Data>
             <Data>

--- a/app/src/main/javascript/package.json
+++ b/app/src/main/javascript/package.json
@@ -45,6 +45,7 @@
     "react-refetch": "^3.0.1",
     "react-svg": "^7.2.14",
     "styled-components": "^5.1.0",
+    "react-is": "^18.2.0",
     "transform-props-with": "^2.2.0",
     "urijs": "^1.19.2",
     "whatwg-fetch": "^3.0.0"


### PR DESCRIPTION
The API of `atlas-react-fetch-loader` changed in https://github.com/ebi-gene-expression-group/atlas-components/commit/72071b2104c1b894d02b2ac5bcd580a058b2a886 to support explicit request parameters in GET requests via an object, rather than by building the resource in the client. This fixes the issue of the tooltip not showing.