### PR TITLE
Bugfix – Apply values of POSTGRES_* variables via `--env-file` when DB is initialised

### DIFF
--- a/docker/docker-compose-postgres-test.yml
+++ b/docker/docker-compose-postgres-test.yml
@@ -10,6 +10,10 @@ services:
     command: -c max_wal_size=1GB
     ports:
       - "5432:5432"
+    environment:
+      - POSTGRES_PASSWORD
+      - POSTGRES_USER
+      - POSTGRES_DB
 
   flyway:
     image: flyway/flyway

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -12,6 +12,10 @@ services:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD
+      - POSTGRES_USER
+      - POSTGRES_DB
 
   flyway:
     image: flyway/flyway


### PR DESCRIPTION
If POSTGRES_* variables aren’t declared, they won’t be in the configuration `environment`

See these two issues for more context:
- https://github.com/docker/compose/issues/10650
- https://github.com/docker-library/postgres/issues/1093