### PR TITLE
Remove RNA-Seq API publication reference from home page

### DIFF
--- a/app/src/main/webapp/WEB-INF/jsp/tiles/views/home/publications.jsp
+++ b/app/src/main/webapp/WEB-INF/jsp/tiles/views/home/publications.jsp
@@ -17,6 +17,20 @@
         </div>
     </a>
 
+    <a href="https://academic.oup.com/bioinformatics/article-lookup/doi/10.1093/bioinformatics/btx143" target="_blank">
+        <div class="media-object">
+            <div class="media-object-section middle">
+                <h3 class="icon icon-conceptual" data-icon="l" />
+            </div>
+            <div class="media-object-section middle">
+                <p>
+                    <strong>The RNASeq-er API – A gateway to systematically updated analysis of public RNA-seq data</strong><br>
+                    <em>Bioinformatics</em>, 22 March 2017.
+                </p>
+            </div>
+        </div>
+    </a>
+
     <a href="http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0107026" target="_blank">
         <div class="media-object">
             <div class="media-object-section middle">

--- a/app/src/main/webapp/WEB-INF/jsp/tiles/views/home/publications.jsp
+++ b/app/src/main/webapp/WEB-INF/jsp/tiles/views/home/publications.jsp
@@ -17,20 +17,6 @@
         </div>
     </a>
 
-    <a href="https://academic.oup.com/bioinformatics/article-lookup/doi/10.1093/bioinformatics/btx143" target="_blank">
-        <div class="media-object">
-            <div class="media-object-section middle">
-                <h3 class="icon icon-conceptual" data-icon="l" />
-            </div>
-            <div class="media-object-section middle">
-                <p>
-                    <strong>The RNASeq-er API – A gateway to systematically updated analysis of public RNA-seq data</strong><br>
-                    <em>Bioinformatics</em>, 22 March 2017.
-                </p>
-            </div>
-        </div>
-    </a>
-
     <a href="http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0107026" target="_blank">
         <div class="media-object">
             <div class="media-object-section middle">


### PR DESCRIPTION
Removed RNA-Seq-er REST API publications link.

Karoy - this PR was created to make sure that all the fixes are available in the develop branch too.