### PR TITLE
Improve build endpoint in  Bulk Expression Atlas

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,11 @@ plugins {
     id 'atlas-web-app.java-conventions'
     id 'war'
     id 'org.flywaydb.flyway' version '7.14.0'
+    id "com.gorylenko.gradle-git-properties" version "2.4.1"
+}
+
+gitProperties {
+    gitPropertiesName = "resources/git.properties"
 }
 
 version '36.0.0'

--- a/app/src/main/java/uk/ac/ebi/atlas/monitoring/JsonBuildInfoController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/monitoring/JsonBuildInfoController.java
@@ -13,14 +13,14 @@ import java.util.Map;
 
 @RestController
 @PropertySource("classpath:configuration.properties")
-public class JsonBuildVersionController extends JsonExceptionHandlingController {
-    private final ImmutableMap<String, String> buildVersion;
+public class JsonBuildInfoController extends JsonExceptionHandlingController {
+    private final ImmutableMap<String, String> buildInfo;
 
-    public JsonBuildVersionController(@Value("${git.build.version}") String buildVersion,
-                                      @Value("${git.branch}") String gitBranch,
-                                      @Value("${git.commit.id}") String gitCommitId,
-                                      @Value("${git.commit.message.full}") String commitMessage) {
-        this.buildVersion = ImmutableMap.of(
+    public JsonBuildInfoController(@Value("${git.build.version}") String buildVersion,
+                                   @Value("${git.branch}") String gitBranch,
+                                   @Value("${git.commit.id}") String gitCommitId,
+                                   @Value("${git.commit.message.full}") String commitMessage) {
+        this.buildInfo = ImmutableMap.of(
                 "Build version", buildVersion,
                 "Git branch", gitBranch,
                 "Latest commit ID", gitCommitId,
@@ -31,6 +31,6 @@ public class JsonBuildVersionController extends JsonExceptionHandlingController 
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public Map<String, String> getBuildInfo() {
-        return buildVersion;
+        return buildInfo;
     }
 }

--- a/app/src/main/java/uk/ac/ebi/atlas/monitoring/JsonBuildVersionController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/monitoring/JsonBuildVersionController.java
@@ -9,30 +9,28 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ebi.atlas.controllers.JsonExceptionHandlingController;
 
-import javax.inject.Inject;
-
-import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
+import java.util.Map;
 
 @RestController
 @PropertySource("classpath:configuration.properties")
 public class JsonBuildVersionController extends JsonExceptionHandlingController {
     private final ImmutableMap<String, String> buildVersion;
 
-    public JsonBuildVersionController(@Value("${build.number}") String buildNumber,
-                                      @Value("${build.branch}") String buildBranch,
-                                      @Value("${build.commitId}") String buildCommitId,
-                                      @Value("${build.tomcatHostname}") String tomcatHostname) {
-        buildVersion = ImmutableMap.of(
-                "bambooBuildVersion", buildNumber,
-                "gitBranch", buildBranch,
-                "gitCommitID", buildCommitId,
-                "tomcatHostname", tomcatHostname);
+    public JsonBuildVersionController(@Value("${git.build.version}") String buildVersion,
+                                      @Value("${git.branch}") String gitBranch,
+                                      @Value("${git.commit.id}") String gitCommitId,
+                                      @Value("${git.commit.message.full}") String commitMessage) {
+        this.buildVersion = ImmutableMap.of(
+                "Build version", buildVersion,
+                "Git branch", gitBranch,
+                "Latest commit ID", gitCommitId,
+                "Latest commit message", commitMessage);
     }
 
     @RequestMapping(value = "/json/build",
-                    method = RequestMethod.GET,
-                    produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    public String getBuildInfo() {
-        return GSON.toJson(buildVersion);
+            method = RequestMethod.GET,
+            produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public Map<String, String> getBuildInfo() {
+        return buildVersion;
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/monitoring/JsonBuildInfoControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/monitoring/JsonBuildInfoControllerWIT.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(classes = TestConfig.class)
-class JsonBuildVersionControllerWIT {
+class JsonBuildInfoControllerWIT {
     @Autowired
     private WebApplicationContext wac;
 

--- a/app/src/test/java/uk/ac/ebi/atlas/monitoring/JsonBuildVersionControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/monitoring/JsonBuildVersionControllerWIT.java
@@ -38,9 +38,9 @@ class JsonBuildVersionControllerWIT {
         mockMvc.perform(get("/json/build"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
-                .andExpect(jsonPath("$.bambooBuildVersion", isA(String.class)))
-                .andExpect(jsonPath("$.gitBranch", isA(String.class)))
-                .andExpect(jsonPath("$.gitCommitID", isA(String.class)))
-                .andExpect(jsonPath("$.tomcatHostname", isA(String.class)));
+                .andExpect(jsonPath("$['Build version']", isA(String.class)))
+                .andExpect(jsonPath("$['Git branch']", isA(String.class)))
+                .andExpect(jsonPath("$['Latest commit ID']", isA(String.class)))
+                .andExpect(jsonPath("$['Latest commit message']", isA(String.class)));
     }
 }

--- a/execute-single-test.sh
+++ b/execute-single-test.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source ${SCRIPT_DIR}/docker/dev.env
 
 function print_usage() {
-  printf '\n%b\n\n' "Usage: ${0} [ -p SUBPROJECT_NAME ] [ -s SCHEMA_VERSION ] -n TEST_NAME"
+  printf '\n%b\n\n' "Usage: ${0} [ -p SUBPROJECT_NAME ] -n TEST_NAME"
   printf '%b\n' "Execute a unit/integration test in a module with the given schema version"
   printf '\n%b\n' "-n\tName of the unit/integration test to execute;\n\tfor example: CellPlotDaoIT"
   printf '\n%b\n' "-p\tName of the sub-project the test can be found;\n\tfor example: app or atlas-web-core (default is app)"
@@ -13,7 +13,6 @@ function print_usage() {
 }
 
 PROJECT_NAME=app
-SCHEMA_VERSION=latest
 mandatory_name=false
 
 while getopts "n:p:h" opt
@@ -62,7 +61,7 @@ gradle clean
 
 gradle \
 -PdataFilesLocation=/atlas-data \
--PexperimentFilesLocation=/atlas-data/gxa \
+-PexperimentFilesLocation=/atlas-data/exp \
 -PexperimentDesignLocation=/atlas-data/expdesign \
 -PjdbcUrl=jdbc:postgresql://${POSTGRES_HOST}:5432/${POSTGRES_DB} \
 -PjdbcUsername=${POSTGRES_USER} \


### PR DESCRIPTION
Changes:

Use gradle-git-properties plugin to provide build information that could be useful to a developer for debugging purposes.
Currently it returns this information:

```json
{
   "Build version": "1.0.0",
   "Git branch": "develop",
   "Latest commit ID": "809f75d6ad696efc2e7fb7edc0b20b95620de1a4",
   "Latest commit message": "Update docker-compose.yml for postgres to follow changes in db-scxa repo"
}
```

We can add more information later if needed.

This PR implementing this issue: https://github.com/ebi-gene-expression-group/atlas-web-single-cell/issues/365

Additional changes:
- I had to fix the declaration of the experiment files location in the single test executor.
- Also removed an unused variable (`SCHEMA_VERSION`) in the single test executor.