### PR TITLE
Correct the mapping on external resources links in supplementary information page

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/controllers/rest/DASFeaturesController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/controllers/rest/DASFeaturesController.java
@@ -60,10 +60,9 @@ public class DASFeaturesController extends HtmlExceptionHandlingController {
         SetMultimap<String, String> factorValuesByType = HashMultimap.create();
         for (DiffAnalytics dbe : diffAnalyticsList) {
             AssayGroup testAssayGroup = dbe.getContrastTestAssayGroup();
-            Experiment experiment = experimentTrader.getPublicExperiment(dbe.getExperimentAccession());
 
             FactorSet factorsForAssayGroup =
-                    FactorSet.create(experiment.getExperimentDesign()
+                    FactorSet.create(experimentTrader.getExperimentDesign(dbe.getExperimentAccession())
                              .getFactorValues(testAssayGroup.getFirstAssayId()));
             for (Factor factor : factorsForAssayGroup) {
                 factorValuesByType.put(factor.getType(), factor.getValue());

--- a/app/src/main/java/uk/ac/ebi/atlas/ebeyedump/DifferentialExperimentContrastLines.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/ebeyedump/DifferentialExperimentContrastLines.java
@@ -3,6 +3,7 @@ package uk.ac.ebi.atlas.ebeyedump;
 import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 import uk.ac.ebi.atlas.model.OntologyTerm;
+import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.experiment.sdrf.FactorSet;
 import uk.ac.ebi.atlas.model.experiment.sdrf.SampleCharacteristic;
 import uk.ac.ebi.atlas.model.experiment.sdrf.Factor;
@@ -18,9 +19,11 @@ import static java.util.stream.Collectors.joining;
 public class DifferentialExperimentContrastLines implements Iterable<String[]> {
     private final LinkedHashSet<ImmutableList<String>> contrastDetails;
     private final LinkedHashSet<ImmutableList<String>> result = new LinkedHashSet<>();
+    private final ExperimentDesign experimentDesign;
 
-    public DifferentialExperimentContrastLines(DifferentialExperiment experiment) {
+    public DifferentialExperimentContrastLines(DifferentialExperiment experiment, ExperimentDesign experimentDesign) {
         this.contrastDetails = buildContrastDetails(experiment);
+        this.experimentDesign = experimentDesign;
     }
 
     private LinkedHashSet<ImmutableList<String>> buildContrastDetails(DifferentialExperiment experiment) {
@@ -43,10 +46,11 @@ public class DifferentialExperimentContrastLines implements Iterable<String[]> {
                                  String assayAccession,
                                  Contrast contrast,
                                  String value) {
-        for (SampleCharacteristic sample : experiment.getExperimentDesign().getSampleCharacteristics(assayAccession)) {
+        final String experimentAccession = experiment.getAccession();
+        for (SampleCharacteristic sample : experimentDesign.getSampleCharacteristics(assayAccession)) {
             ImmutableList<String> line =
                     ImmutableList.of(
-                            experiment.getAccession(),
+                            experimentAccession,
                             contrast.getId(),
                             value,
                             "characteristic",
@@ -61,12 +65,13 @@ public class DifferentialExperimentContrastLines implements Iterable<String[]> {
                                  String assayAccession,
                                  Contrast contrast,
                                  String value) {
-        FactorSet factorSet = experiment.getExperimentDesign().getFactors(assayAccession);
+        final String experimentAccession = experiment.getAccession();
+        FactorSet factorSet = experimentDesign.getFactors(assayAccession);
         if (factorSet != null) {
             for (Factor factor : factorSet) {
                 ImmutableList<String> line =
                         ImmutableList.of(
-                                experiment.getAccession(),
+                                experimentAccession,
                                 contrast.getId(),
                                 value,
                                 "factor",

--- a/app/src/main/java/uk/ac/ebi/atlas/ebeyedump/ExperimentsConditionsDetailsController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/ebeyedump/ExperimentsConditionsDetailsController.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
+import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperiment;
 import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
@@ -26,7 +27,7 @@ import static uk.ac.ebi.atlas.model.experiment.ExperimentType.RNASEQ_MRNA_DIFFER
 @Controller
 @Scope("request")
 public class ExperimentsConditionsDetailsController {
-    private ExperimentTrader experimentTrader;
+    private final ExperimentTrader experimentTrader;
 
     public ExperimentsConditionsDetailsController(ExperimentTrader experimentTrader) {
         this.experimentTrader = experimentTrader;
@@ -36,7 +37,8 @@ public class ExperimentsConditionsDetailsController {
     public void generateTsvFormatBaseline(HttpServletResponse response) {
         writeTsvLinesToResponse(
                 response,
-                experiment -> new BaselineExperimentAssayGroupsLines((BaselineExperiment) experiment),
+                experiment -> new BaselineExperimentAssayGroupsLines(
+                        (BaselineExperiment) experiment, getExperimentDesign(experiment.getAccession())),
                 RNASEQ_MRNA_BASELINE,
                 PROTEOMICS_BASELINE,
                 PROTEOMICS_BASELINE_DIA);
@@ -46,11 +48,16 @@ public class ExperimentsConditionsDetailsController {
     public void generateTsvFormatDifferential(HttpServletResponse response) {
         writeTsvLinesToResponse(
                 response,
-                experiment -> new DifferentialExperimentContrastLines((DifferentialExperiment) experiment),
+                experiment -> new DifferentialExperimentContrastLines(
+                        (DifferentialExperiment) experiment, getExperimentDesign(experiment.getAccession())),
                 MICROARRAY_1COLOUR_MICRORNA_DIFFERENTIAL,
                 MICROARRAY_1COLOUR_MRNA_DIFFERENTIAL,
                 MICROARRAY_2COLOUR_MRNA_DIFFERENTIAL,
                 RNASEQ_MRNA_DIFFERENTIAL);
+    }
+
+    private ExperimentDesign getExperimentDesign(String experimentAccession) {
+        return experimentTrader.getExperimentDesign(experimentAccession);
     }
 
     private void writeTsvLinesToResponse(HttpServletResponse response,

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExpressionAtlasContentService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExpressionAtlasContentService.java
@@ -131,7 +131,7 @@ public class ExpressionAtlasContentService {
                                                  String accessKey,
                                                  ExternallyAvailableContent.ContentType contentType) {
         Experiment<?> experiment = experimentTrader.getExperiment(experimentAccession, accessKey);
-        ImmutableList.Builder<ExternallyAvailableContent> arrayExpressAndOtherExternalResourcesLinks = ImmutableList.builder();
+        var externalResourcesLinks = ImmutableList.builder();
         ImmutableList.Builder<ExternallyAvailableContent> otherExternalResourceLinks;
 
         switch (experiment.getType()) {

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExpressionAtlasContentService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/ExpressionAtlasContentService.java
@@ -1,6 +1,7 @@
 package uk.ac.ebi.atlas.experimentpage;
 
 import com.google.common.collect.ImmutableList;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.experimentpage.differential.download.DifferentialSecondaryDataFiles;
 import uk.ac.ebi.atlas.experimentpage.link.LinkToArrayExpress;
@@ -44,6 +45,7 @@ public class ExpressionAtlasContentService {
 
     private final ExperimentTrader experimentTrader;
 
+    @Autowired
     public ExpressionAtlasContentService(
             ExperimentDownloadSupplier.Proteomics proteomicsExperimentDownloadSupplier,
             ExperimentDownloadSupplier.RnaSeqBaseline rnaSeqBaselineExperimentDownloadSupplier,

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/baseline/BaselineExperimentPageService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/baseline/BaselineExperimentPageService.java
@@ -9,6 +9,7 @@ import uk.ac.ebi.atlas.experimentpage.baseline.coexpression.CoexpressedGenesServ
 import uk.ac.ebi.atlas.experimentpage.baseline.profiles.BaselineExperimentProfilesListSerializer;
 import uk.ac.ebi.atlas.experimentpage.baseline.profiles.BaselineExperimentProfilesService;
 import uk.ac.ebi.atlas.experimentpage.context.BaselineRequestContext;
+import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.experiment.sample.AssayGroup;
 import uk.ac.ebi.atlas.model.ExpressionUnit;
 import uk.ac.ebi.atlas.model.GeneProfilesList;
@@ -38,12 +39,13 @@ public class BaselineExperimentPageService extends ExperimentPageService {
     }
 
     public <U extends ExpressionUnit.Absolute> JsonObject getResultsForExperiment(
-            BaselineExperiment experiment, String accessKey, BaselineRequestPreferences<U> preferences) {
+            BaselineExperiment experiment, ExperimentDesign experimentDesign, String accessKey,
+            BaselineRequestPreferences<U> preferences) {
 
         BaselineRequestContext<U> requestContext = new BaselineRequestContext<>(preferences, experiment);
 
         JsonObject result = new JsonObject();
-        result.add("columnHeaders", constructColumnHeaders(requestContext, experiment));
+        result.add("columnHeaders", constructColumnHeaders(requestContext, experiment, experimentDesign));
         result.add("columnGroupings", new JsonArray());
 
         GeneProfilesList<BaselineProfile> baselineProfilesList = fetchProfiles(experiment, preferences);
@@ -88,7 +90,8 @@ public class BaselineExperimentPageService extends ExperimentPageService {
         return baselineProfilesList;
     }
 
-    private JsonArray constructColumnHeaders(BaselineRequestContext<?> requestContext, BaselineExperiment experiment) {
+    private JsonArray constructColumnHeaders(BaselineRequestContext<?> requestContext, BaselineExperiment experiment,
+                                             ExperimentDesign experimentDesign) {
         JsonArray result = new JsonArray();
 
         for (AssayGroup dataColumnDescriptor : requestContext.getDataColumnsToReturn()) {
@@ -101,7 +104,7 @@ public class BaselineExperimentPageService extends ExperimentPageService {
             o.add("assayGroupSummary",
                     new AssayGroupSummaryBuilder()
                     .forAssayGroup(experiment.getDataColumnDescriptor(dataColumnDescriptor.getId()))
-                    .withExperimentDesign(experiment.getExperimentDesign())
+                    .withExperimentDesign(experimentDesign)
                     .build().toJson());
             result.add(o);
         }

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/content/ExperimentPageContentService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/content/ExperimentPageContentService.java
@@ -22,6 +22,7 @@ import uk.ac.ebi.atlas.model.experiment.ExperimentDesignTable;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import uk.ac.ebi.atlas.model.experiment.sample.ReportsGeneExpression;
 import uk.ac.ebi.atlas.resource.DataFileHub;
+import uk.ac.ebi.atlas.trader.ExperimentTrader;
 import uk.ac.ebi.atlas.utils.GsonProvider;
 
 import java.util.List;
@@ -39,10 +40,14 @@ public class ExperimentPageContentService {
 
     private final DataFileHub dataFileHub;
     private final ExpressionAtlasContentService expressionAtlasContentService;
+    private final ExperimentTrader experimentTrader;
 
-    public ExperimentPageContentService(DataFileHub dataFileHub, ExpressionAtlasContentService expressionAtlasContentService) {
+    public ExperimentPageContentService(DataFileHub dataFileHub,
+                                        ExpressionAtlasContentService expressionAtlasContentService,
+                                        ExperimentTrader experimentTrader) {
         this.dataFileHub = dataFileHub;
         this.expressionAtlasContentService = expressionAtlasContentService;
+        this.experimentTrader = experimentTrader;
     }
 
     @Cacheable(cacheNames = "experimentContent", key = "#experiment.getAccession()")
@@ -66,7 +71,8 @@ public class ExperimentPageContentService {
         // everything wants to have a heatmap
         availableTabs.add(
                 heatmapTab(
-                        GSON.toJsonTree(getExperimentVariablesAsHeatmapFilterGroups(experiment)).getAsJsonArray(),
+                        GSON.toJsonTree(getExperimentVariablesAsHeatmapFilterGroups(experiment,
+                                experimentTrader.getExperimentDesign(experiment.getAccession()))).getAsJsonArray(),
                         JsonBaselineExperimentController.geneDistributionUrl(
                                 experiment.getAccession(),
                                 accessKey,
@@ -90,7 +96,7 @@ public class ExperimentPageContentService {
 
         if (dataFileHub.getExperimentFiles(experiment.getAccession()).experimentDesign.exists()) {
             availableTabs.add(
-                    experimentDesignTab(new ExperimentDesignTable(experiment).asJson(),
+                    experimentDesignTab(new ExperimentDesignTable(experimentTrader, experiment).asJson(),
                             ExperimentDesignFile.makeUrl(experiment.getAccession(), accessKey)));
         }
 

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/content/HeatmapGroupingsService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/content/HeatmapGroupingsService.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Streams;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
+import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperiment;
 import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
 import uk.ac.ebi.atlas.model.experiment.sample.Contrast;
@@ -47,10 +48,13 @@ public class HeatmapGroupingsService {
     }
 
     // TODO Cache results of serialized JSON
-    public static ImmutableList<HeatmapFilterGroup> getExperimentVariablesAsHeatmapFilterGroups(Experiment<?> experiment) {
+    public static ImmutableList<HeatmapFilterGroup> getExperimentVariablesAsHeatmapFilterGroups(
+            Experiment<?> experiment,
+            ExperimentDesign experimentDesign) {
+        final String experimentAccession = experiment.getAccession();
         if (!(experiment instanceof BaselineExperiment) && !(experiment instanceof DifferentialExperiment)) {
             throw new IllegalArgumentException(
-                    "Experiment " + experiment.getAccession() + " of type " + experiment.getType() + " is not " +
+                    "Experiment " + experimentAccession + " of type " + experiment.getType() + " is not " +
                     "supported for heatmap display");
         }
 
@@ -84,7 +88,7 @@ public class HeatmapGroupingsService {
                 Streams.concat(
                             Stream.of(experiment.getDisplayDefaults().getDefaultQueryFactorType()),
                             experiment.getDisplayDefaults().getFactorTypes().stream(),
-                            experiment.getExperimentDesign().getFactorHeaders().stream())
+                            experimentDesign.getFactorHeaders().stream())
                         .filter(StringUtils::isNotBlank)    // defaultQueryFactorType in diff experiments is ""
                         .map(Factor::normalize)
                         .collect(toImmutableSet());
@@ -101,17 +105,19 @@ public class HeatmapGroupingsService {
                                         experiment.getDisplayDefaults()
                                                 .defaultFilterValuesForFactor(factorHeader)
                                                 .orElse(ALL_VALUES_KEYWORD),
-                                        mapAssayGroupsToFactors(assayId2AssayGroup, factorHeader, experiment)));
+                                        mapAssayGroupsToFactors(experimentDesign, assayId2AssayGroup, factorHeader,
+                                                experiment)));
 
         Stream<HeatmapFilterGroup> sampleCharacteristicGroups =
-                experiment.getExperimentDesign().getSampleCharacteristicHeaders().stream()
+                experimentDesign.getSampleCharacteristicHeaders().stream()
                         .filter(sampleCharacteristicHeader -> !orderedFactors.contains(Factor.normalize(sampleCharacteristicHeader)))
                         .map(sampleCharacteristicHeader ->
                                 HeatmapFilterGroup.create(
                                         sampleCharacteristicHeader,
                                         primaryVariables.contains(sampleCharacteristicHeader),
                                         ALL_VALUES_KEYWORD,
-                                        mapAssayGroupsToSampleCharacteristics(assayId2AssayGroup, sampleCharacteristicHeader, experiment)));
+                                        mapAssayGroupsToSampleCharacteristics(experimentDesign, assayId2AssayGroup,
+                                                sampleCharacteristicHeader, experiment)));
 
         return Streams.concat(
                     mainFilterGroup.map(Stream::of).orElseGet(Stream::empty),
@@ -122,31 +128,29 @@ public class HeatmapGroupingsService {
 
     @NotNull
     private static ImmutableSetMultimap<String, String> mapAssayGroupsToFactors(
+            ExperimentDesign experimentDesign,
             @NotNull ImmutableMultimap<String, String> assayId2AssayGroup,
             @NotNull String factorHeader,
             @NotNull Experiment<@NotNull ?> experiment) {
         return assayId2AssayGroup.keySet().stream()
-                .filter(assayId -> experiment.getExperimentDesign().getFactor(assayId, factorHeader) != null)
+                .filter(assayId -> experimentDesign.getFactor(assayId, factorHeader) != null)
                 .collect(flatteningToImmutableSetMultimap(
-                        assayId -> experiment.getExperimentDesign().getFactor(assayId, factorHeader).getValue(),
+                        assayId -> experimentDesign.getFactor(assayId, factorHeader).getValue(),
                         assayId -> assayId2AssayGroup.get(assayId).stream()));
     }
 
     @NotNull
     private static ImmutableSetMultimap<String, String> mapAssayGroupsToSampleCharacteristics(
+            ExperimentDesign experimentDesign,
             @NotNull ImmutableMultimap<String, String> assayId2AssayGroup,
             @NotNull String sampleCharacteristicHeader,
             @NotNull Experiment<@NotNull?> experiment) {
         return assayId2AssayGroup.keySet().stream()
                 .filter(assayId ->
-                        experiment
-                                .getExperimentDesign()
-                                .getSampleCharacteristic(assayId, sampleCharacteristicHeader) != null)
+                        experimentDesign.getSampleCharacteristic(assayId, sampleCharacteristicHeader) != null)
                 .collect(flatteningToImmutableSetMultimap(
                         assayId ->
-                                experiment
-                                        .getExperimentDesign()
-                                        .getSampleCharacteristic(assayId, sampleCharacteristicHeader).getValue(),
+                                experimentDesign.getSampleCharacteristic(assayId, sampleCharacteristicHeader).getValue(),
                         assayId -> assayId2AssayGroup.get(assayId).stream()));
     }
 }

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/differential/DifferentialExperimentPageService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/differential/DifferentialExperimentPageService.java
@@ -9,6 +9,7 @@ import uk.ac.ebi.atlas.experimentpage.link.LinkToGene;
 import uk.ac.ebi.atlas.experimentpage.context.DifferentialRequestContext;
 import uk.ac.ebi.atlas.experimentpage.context.DifferentialRequestContextFactory;
 import uk.ac.ebi.atlas.model.ExpressionUnit;
+import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.experiment.sample.Contrast;
 import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExperiment;
 import uk.ac.ebi.atlas.model.experiment.differential.DifferentialExpression;
@@ -43,10 +44,10 @@ DifferentialExperimentPageService<
         this.differentialRequestContextFactory = differentialRequestContextFactory;
         this.profilesHeatMap = profilesHeatMap;
         this.contrastImageTrader = contrastImageTrader;
-
     }
 
-    public JsonObject getResultsForExperiment(E experiment, String accessKey, K preferences) {
+    public JsonObject getResultsForExperiment(E experiment, ExperimentDesign experimentDesign,
+                                              String accessKey, K preferences) {
 
         JsonObject result = new JsonObject();
         R requestContext = differentialRequestContextFactory.create(experiment, preferences);
@@ -60,7 +61,7 @@ DifferentialExperimentPageService<
         }
 
         result.add("columnGroupings", new JsonArray());
-        result.add("columnHeaders", constructColumnHeaders(contrasts, experiment));
+        result.add("columnHeaders", constructColumnHeaders(contrasts, experiment, experimentDesign));
         result.add("profiles", new ExternallyViewableProfilesList<>(
                 profiles, new LinkToGene<>(), requestContext.getDataColumnsToReturn(),
                 p -> ExpressionUnit.Relative.FOLD_CHANGE).asJson());
@@ -68,15 +69,16 @@ DifferentialExperimentPageService<
         return result;
     }
 
-    private JsonArray constructColumnHeaders(Iterable<Contrast> contrasts, DifferentialExperiment
-            differentialExperiment) {
+    private JsonArray constructColumnHeaders(Iterable<Contrast> contrasts,
+                                             DifferentialExperiment differentialExperiment,
+                                             ExperimentDesign experimentDesign) {
         JsonArray result = new JsonArray();
         Map<String, JsonArray> contrastImages = contrastImageTrader.contrastImages(differentialExperiment);
         for (Contrast contrast : contrasts) {
             JsonObject o = contrast.toJson();
             o.add("contrastSummary", new ContrastSummaryBuilder()
                     .forContrast(contrast)
-                    .withExperimentDesign(differentialExperiment.getExperimentDesign())
+                    .withExperimentDesign(experimentDesign)
                     .withExperimentDescription(differentialExperiment.getDescription())
                     .build().toJson());
             o.add("resources", contrastImages.get(contrast.getId()));

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/json/JsonBaselineExperimentController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/json/JsonBaselineExperimentController.java
@@ -49,7 +49,8 @@ public class JsonBaselineExperimentController extends JsonExperimentController {
         super(experimentTrader);
 
         this.baselineExperimentPageService =
-                new BaselineExperimentPageService(baselineExperimentProfilesService, coexpressedGenesService);
+                new BaselineExperimentPageService(
+                        baselineExperimentProfilesService, coexpressedGenesService);
 
         this.rnaSeqHistograms =
                 new HistogramService.RnaSeq(rnaSeqBaselineProfileStreamFactory, experimentTrader);
@@ -67,6 +68,7 @@ public class JsonBaselineExperimentController extends JsonExperimentController {
         return GSON.toJson(
                 baselineExperimentPageService.getResultsForExperiment(
                         (BaselineExperiment) experimentTrader.getExperiment(experimentAccession, accessKey),
+                        experimentTrader.getExperimentDesign(experimentAccession),
                         accessKey,
                         preferences));
     }

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/json/JsonDifferentialExperimentController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/json/JsonDifferentialExperimentController.java
@@ -78,6 +78,7 @@ public class JsonDifferentialExperimentController extends JsonExperimentControll
                                                         String accessKey) {
         return GSON.toJson(diffMicroarrayExperimentPageService.getResultsForExperiment(
                 (MicroarrayExperiment) experimentTrader.getExperiment(experimentAccession, accessKey),
+                experimentTrader.getExperimentDesign(experimentAccession),
                 accessKey,
                 preferences));
     }
@@ -125,6 +126,7 @@ public class JsonDifferentialExperimentController extends JsonExperimentControll
             @RequestParam(defaultValue = "") String accessKey) {
         return GSON.toJson(differentialExperimentPageService.getResultsForExperiment(
                 (DifferentialExperiment) experimentTrader.getExperiment(experimentAccession, accessKey),
+                experimentTrader.getExperimentDesign(experimentAccession),
                 accessKey, preferences));
     }
 
@@ -138,6 +140,7 @@ public class JsonDifferentialExperimentController extends JsonExperimentControll
             @RequestParam(defaultValue = "") String accessKey) {
         return GSON.toJson(differentialExperimentPageService.getResultsForExperiment(
                 (DifferentialExperiment) experimentTrader.getExperiment(experimentAccession, accessKey),
+                experimentTrader.getExperimentDesign(experimentAccession),
                 accessKey, preferences));
     }
 }

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/json/opentargets/OpenTargetsEvidenceController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/json/opentargets/OpenTargetsEvidenceController.java
@@ -53,7 +53,8 @@ public class OpenTargetsEvidenceController extends JsonExperimentController {
         String resourcesVersion = "prod.30";
 
         bulkDifferentialEvidenceService =
-                new EvidenceService<>(bulkDifferentialProfileStreamFactory, dataFileHub, resourcesVersion);
+                new EvidenceService<>(
+                        bulkDifferentialProfileStreamFactory, dataFileHub, resourcesVersion);
         diffMicroarrayEvidenceService =
                 new EvidenceService<>(microarrayProfileStreamFactory, dataFileHub, resourcesVersion);
     }
@@ -77,6 +78,7 @@ public class OpenTargetsEvidenceController extends JsonExperimentController {
         PrintWriter responseWriter = response.getWriter();
         diffMicroarrayEvidenceService.evidenceForExperiment(
                 experiment,
+                experimentTrader.getExperimentDesign(experimentAccession),
                 contrast -> {
                     MicroarrayRequestPreferences requestPreferences = new MicroarrayRequestPreferences();
                     requestPreferences.setFoldChangeCutoff(logFoldChangeCutoff);
@@ -158,6 +160,7 @@ public class OpenTargetsEvidenceController extends JsonExperimentController {
         PrintWriter printWriter = response.getWriter();
         bulkDifferentialEvidenceService.evidenceForExperiment(
                 experiment,
+                experimentTrader.getExperimentDesign(experimentAccession),
                 contrast -> {
                     DifferentialRequestPreferences requestPreferences = new DifferentialRequestPreferences();
                     requestPreferences.setFoldChangeCutoff(logFoldChangeCutoff);

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tooltip/ContrastSummaryController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tooltip/ContrastSummaryController.java
@@ -22,7 +22,7 @@ import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 @Scope("request")
 public class ContrastSummaryController {
 
-    private ExperimentTrader experimentTrader;
+    private final ExperimentTrader experimentTrader;
 
     @Inject
     public ContrastSummaryController(ExperimentTrader experimentTrader) {
@@ -44,7 +44,7 @@ public class ContrastSummaryController {
             throw new IllegalArgumentException("No contrast with ID " + contrastId + " found.");
         }
 
-        ExperimentDesign experimentDesign = differentialExperiment.getExperimentDesign();
+        ExperimentDesign experimentDesign = experimentTrader.getExperimentDesign(experimentAccession);
 
         ContrastSummary contrastSummary = new ContrastSummaryBuilder()
                 .withExperimentDesign(experimentDesign)

--- a/app/src/main/java/uk/ac/ebi/atlas/trader/GxaExperimentRepository.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/trader/GxaExperimentRepository.java
@@ -9,6 +9,7 @@ import uk.ac.ebi.atlas.controllers.ResourceNotFoundException;
 import uk.ac.ebi.atlas.experimentimport.ExperimentCrudDao;
 import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
+import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.trader.factory.BaselineExperimentFactory;
 import uk.ac.ebi.atlas.trader.factory.MicroarrayExperimentFactory;
 import uk.ac.ebi.atlas.trader.factory.ProteomicsDifferentialExperimentFactory;
@@ -54,7 +55,7 @@ public class GxaExperimentRepository implements ExperimentRepository {
 
         LOGGER.info("Building experiment {}...", experimentAccession);
 
-        var experimentDesign = experimentDesignParser.parse(experimentDto.getExperimentAccession());
+        var experimentDesign = getExperimentDesign(experimentAccession);
         var idfParserOutput = idfParser.parse(experimentDto.getExperimentAccession());
         switch (experimentDto.getExperimentType()) {
             case PROTEOMICS_BASELINE:
@@ -110,5 +111,10 @@ public class GxaExperimentRepository implements ExperimentRepository {
     @Override
     public String getExperimentType(String experimentAccession) {
         return experimentCrudDao.getExperimentType(experimentAccession);
+    }
+
+    @Override
+    public ExperimentDesign getExperimentDesign(String experimentAccession) {
+        return experimentDesignParser.parse(experimentAccession);
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/ebeyedump/BaselineExperimentAssayGroupsLinesTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/ebeyedump/BaselineExperimentAssayGroupsLinesTest.java
@@ -14,6 +14,7 @@ import uk.ac.ebi.atlas.model.OntologyTerm;
 import uk.ac.ebi.atlas.model.experiment.sdrf.SampleCharacteristic;
 import uk.ac.ebi.atlas.model.experiment.ExperimentDesign;
 import uk.ac.ebi.atlas.model.experiment.baseline.BaselineExperiment;
+import uk.ac.ebi.atlas.trader.ExperimentTrader;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -79,23 +80,19 @@ public class BaselineExperimentAssayGroupsLinesTest {
         SampleCharacteristic sampleCharacteristic2 =
                 SampleCharacteristic.create(SAMPLE_HEADER, SAMPLE_VALUE2, SAMPLE_ONTOLOGY_TERM2);
 
-
         experimentDesign.putSampleCharacteristic(ASSAY1, SAMPLE_HEADER, sampleCharacteristic1);
-        experimentDesign.putFactor(ASSAY1, FACTOR_HEADER, FACTOR_VALUE1, FACTOR_ONTOLOGY_TERM1);
-
         experimentDesign.putSampleCharacteristic(ASSAY2, SAMPLE_HEADER, sampleCharacteristic2);
-        experimentDesign.putFactor(ASSAY2, FACTOR_HEADER, FACTOR_VALUE2, FACTOR_ONTOLOGY_TERM2);
-
         experimentDesign.putSampleCharacteristic(ASSAY3, SAMPLE_HEADER, SAMPLE_VALUE3);
+        experimentDesign.putFactor(ASSAY1, FACTOR_HEADER, FACTOR_VALUE1, FACTOR_ONTOLOGY_TERM1);
+        experimentDesign.putFactor(ASSAY2, FACTOR_HEADER, FACTOR_VALUE2, FACTOR_ONTOLOGY_TERM2);
         experimentDesign.putFactor(ASSAY3, FACTOR_HEADER, FACTOR_VALUE3);
-
 
         when(baselineExperiment.getAccession()).thenReturn(EXPERIMENT_ACCESSION);
         when(baselineExperiment.getDataColumnDescriptors()).thenReturn(ImmutableList.of(ASSAY_GROUP1, ASSAY_GROUP2,
                 ASSAY_GROUP3));
-        when(baselineExperiment.getExperimentDesign()).thenReturn(experimentDesign);
 
-        BaselineExperimentAssayGroupsLines subject = new BaselineExperimentAssayGroupsLines(baselineExperiment);
+        BaselineExperimentAssayGroupsLines subject =
+                new BaselineExperimentAssayGroupsLines(baselineExperiment, experimentDesign);
 
         Iterator<String[]> lines = subject.iterator();
 

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/json/opentargets/EvidenceServiceIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/json/opentargets/EvidenceServiceIT.java
@@ -66,7 +66,8 @@ class EvidenceServiceIT {
 
     @BeforeEach
     void setUp() {
-        subject = new EvidenceService<>(microarrayProfileStreamFactory, dataFileHub, "test");
+        subject = new EvidenceService<>(
+                microarrayProfileStreamFactory, dataFileHub, "test");
     }
 
     @Test
@@ -74,7 +75,9 @@ class EvidenceServiceIT {
         var listBuilder = ImmutableList.<JsonObject>builder();
         var experiment = (MicroarrayExperiment) experimentTrader.getPublicExperiment("E-GEOD-40611");
         subject.evidenceForExperiment(
-                experiment, contrast -> {
+                experiment,
+                experimentTrader.getExperimentDesign(experiment.getAccession()),
+                contrast -> {
                     var requestPreferences = new MicroarrayRequestPreferences();
                     requestPreferences.setHeatmapMatrixSize(1000);
                     requestPreferences.setSelectedColumnIds(ImmutableSet.of(contrast.getId()));
@@ -94,7 +97,9 @@ class EvidenceServiceIT {
         var listBuilder = ImmutableList.<JsonObject>builder();
         var experiment = (MicroarrayExperiment) experimentTrader.getPublicExperiment("E-GEOD-40611");
         subject.evidenceForExperiment(
-                experiment, contrast -> {
+                experiment,
+                experimentTrader.getExperimentDesign(experiment.getAccession()),
+                contrast -> {
                     var requestPreferences = new MicroarrayRequestPreferences();
                     requestPreferences.setHeatmapMatrixSize(1000);
                     requestPreferences.setSelectedColumnIds(ImmutableSet.of(contrast.getId()));

--- a/app/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentGroupingsForHeatmapIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/model/experiment/ExperimentGroupingsForHeatmapIT.java
@@ -84,7 +84,8 @@ class ExperimentGroupingsForHeatmapIT {
                 .collect(Collectors.toList());
 
         JsonArray result =
-                GSON.toJsonTree(HeatmapGroupingsService.getExperimentVariablesAsHeatmapFilterGroups(experiment))
+                GSON.toJsonTree(HeatmapGroupingsService.getExperimentVariablesAsHeatmapFilterGroups(
+                                experiment, experimentTrader.getExperimentDesign(accession)))
                         .getAsJsonArray();
 
         assertThat(result.size(), greaterThan(0));


### PR DESCRIPTION
This is a big change on external resources links, basically we would like to decouple the logic from experiment type and the external resources. The detailed rules are given by Silvie stated in the related issue.

https://github.com/ebi-gene-expression-group/atlas-web-bulk/issues/195