### PR TITLE
Fix initialisation order in DifferentialExperimentContrastLines's constructor

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/ebeyedump/DifferentialExperimentContrastLines.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/ebeyedump/DifferentialExperimentContrastLines.java
@@ -22,8 +22,8 @@ public class DifferentialExperimentContrastLines implements Iterable<String[]> {
     private final ExperimentDesign experimentDesign;
 
     public DifferentialExperimentContrastLines(DifferentialExperiment experiment, ExperimentDesign experimentDesign) {
-        this.contrastDetails = buildContrastDetails(experiment);
         this.experimentDesign = experimentDesign;
+        this.contrastDetails = buildContrastDetails(experiment);
     }
 
     private LinkedHashSet<ImmutableList<String>> buildContrastDetails(DifferentialExperiment experiment) {


### PR DESCRIPTION
Experiment design variable was initialised after it was used in buildContrastDetails method in the constructor.
For this reason we got a NPE exception when we tried to use it in the buildContrastDetails method.
I had to swap the initialisation order in DifferentialExperimentContrastLines's constructor.

Unfortunately nobody wrote tests for this class. :-(
We need to merge and deploy this change ASAP.
I am going to add a ticket for writing tests and that is going to be done later, hopefully during next sprint.
Not very ideal. :-( 