### PR TITLE
Set HttpOnly argument for cookies to true

### DIFF
--- a/app/src/main/webapp/META-INF/context.xml
+++ b/app/src/main/webapp/META-INF/context.xml
@@ -2,6 +2,7 @@
 <!-- In production environments set deployXML="false" in the relevant <Host> section in server.xml, and add gxa.xml
      to e.g. $CATALINA_BASE/conf/Catalina/localhost to configure the location of properties files -->
 <Context>
+    <CookieProcessor useHttpOnly="true"/>
     <Resources className="org.apache.catalina.webresources.StandardRoot">
         <PreResources className="org.apache.catalina.webresources.DirResourceSet"
                       base="/webapp-properties"

--- a/app/src/main/webapp/WEB-INF/web.xml
+++ b/app/src/main/webapp/WEB-INF/web.xml
@@ -53,6 +53,10 @@
     <listener>
         <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
     </listener>
+    
+    <listener>
+        <listener-class>uk.ac.ebi.atlas.configuration.HttpOnlyCookieConfigurator</listener-class>
+    </listener>
 
     <filter>
         <filter-name>UrlRewriteFilter</filter-name>
@@ -95,6 +99,20 @@
         <url-pattern>/sc/json/*</url-pattern>
     </filter-mapping>
 
+    <filter>
+        <filter-name>httpHeaderSecurity</filter-name>
+        <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>
+        <async-supported>true</async-supported>
+        <init-param>
+            <param-name>hstsEnabled</param-name>
+            <param-value>true</param-value>
+        </init-param>
+    </filter>
+    <filter-mapping>
+        <filter-name>httpHeaderSecurity</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
     <security-role>
         <role-name>admin</role-name>
     </security-role>
@@ -123,8 +141,10 @@
         <auth-constraint />
     </security-constraint>
 
-    <!-- Disable JSessionID -->
     <session-config>
+        <cookie-config>
+            <http-only>true</http-only>
+        </cookie-config>
         <tracking-mode>COOKIE</tracking-mode>
     </session-config>
 

--- a/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'uk.ac.ebi.ge'
-version = '36.6.1'
+version = '36.7.0'
 
 sourceCompatibility = 11
 targetCompatibility = 11


### PR DESCRIPTION
With this change we increase the security of the cookies by set the `HttpOnly` parameters of the cookies to `true`.
We set it in 3 different ways:
- in the web.xml file
- in the context.xml file
- create a new listener that set this argument (HttpOnly) to true.