### PR TITLE
Refactor download page using ThymeLeaf

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,9 @@ dependencies {
     runtimeOnly "org.cache2k:cache2k-core:${cache2kVersion}"
     implementation "org.cache2k:cache2k-spring:${cache2kVersion}"
 
+    implementation 'org.thymeleaf:thymeleaf:3.1.2.RELEASE'
+    implementation 'org.thymeleaf:thymeleaf-spring5:3.1.2.RELEASE'
+
     runtimeOnly 'org.apache.tiles:tiles-extras:3.0.8'
     // For URL rewrite (see WEB-INF/web.xml), or your Filter will fail with the most confusing error messages
     runtimeOnly 'org.tuckey:urlrewritefilter:4.0.3'

--- a/app/src/main/java/uk/ac/ebi/atlas/configuration/WebConfig.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/configuration/WebConfig.java
@@ -10,10 +10,15 @@ import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.ViewResolverRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import org.springframework.web.servlet.view.tiles3.TilesConfigurer;
 import org.springframework.web.servlet.view.tiles3.TilesView;
+import org.thymeleaf.spring5.SpringTemplateEngine;
+import org.thymeleaf.spring5.view.ThymeleafViewResolver;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
 import uk.ac.ebi.atlas.model.ExpressionUnit;
 import uk.ac.ebi.atlas.model.ExpressionUnitPropertyEditor;
 import uk.ac.ebi.atlas.resource.DataFileHub;
@@ -67,6 +72,50 @@ public class WebConfig implements WebMvcConfigurer {
         UrlBasedViewResolver resolver = new UrlBasedViewResolver();
         resolver.setViewClass(TilesView.class);
         return resolver;
+    }
+
+    @Bean
+    public ClassLoaderTemplateResolver rootThymeleafTemplateResolver() {
+        ClassLoaderTemplateResolver resolver = new ClassLoaderTemplateResolver();
+        resolver.setPrefix("templates/thymeleaf/");
+        resolver.setSuffix(".html");
+        resolver.setTemplateMode(TemplateMode.HTML);
+        resolver.setCharacterEncoding("UTF-8");
+        resolver.setCheckExistence(true);
+        return resolver;
+    }
+
+    @Bean
+    public ClassLoaderTemplateResolver viewsThymeleafTemplateResolver() {
+        ClassLoaderTemplateResolver resolver = new ClassLoaderTemplateResolver();
+        resolver.setPrefix("templates/thymeleaf/views/");
+        resolver.setSuffix(".html");
+        resolver.setTemplateMode(TemplateMode.HTML);
+        resolver.setCharacterEncoding("UTF-8");
+        resolver.setCheckExistence(true);
+        return resolver;
+    }
+
+    @Bean
+    public SpringTemplateEngine thymeleafTemplateEngine() {
+        SpringTemplateEngine templateEngine = new SpringTemplateEngine();
+        templateEngine.addTemplateResolver(viewsThymeleafTemplateResolver());
+        templateEngine.addTemplateResolver(rootThymeleafTemplateResolver());
+        return templateEngine;
+    }
+
+    @Bean
+    public ThymeleafViewResolver thymeleafViewResolver() {
+        ThymeleafViewResolver resolver = new ThymeleafViewResolver();
+        resolver.setTemplateEngine(thymeleafTemplateEngine());
+        resolver.setCharacterEncoding("UTF-8");
+        return resolver;
+    }
+
+    @Override
+    public void configureViewResolvers(ViewResolverRegistry registry) {
+        registry.viewResolver(urlBasedViewResolver());
+        registry.viewResolver(thymeleafViewResolver());
     }
 
     @InitBinder

--- a/app/src/main/java/uk/ac/ebi/atlas/download/DownloadController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/download/DownloadController.java
@@ -9,8 +9,8 @@ import uk.ac.ebi.atlas.controllers.HtmlExceptionHandlingController;
 public class DownloadController extends HtmlExceptionHandlingController {
 
     @RequestMapping(value = "/download", produces = "text/html;charset=UTF-8")
-    public String getExperimentsListParameters(Model model) {
-        model.addAttribute("mainTitle", "Download ");
+    public String downloadPage(Model model) {
+        model.addAttribute("title", "Download &lt; ");
 
         return "download";
     }

--- a/app/src/main/resources/templates/thymeleaf/fragments/base.html
+++ b/app/src/main/resources/templates/thymeleaf/fragments/base.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html th:fragment="base(content)" xmlns:th="http://www.thymeleaf.org" lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title th:text="${title}">Expression Atlas &lt; EMBL-EBI</title>
+    <meta name="description" content="EMBL-EBI Expression Atlas, an open public repository of gene expression pattern data under different biological conditions">
+    <meta name="keywords" content="expression atlas, gene expression, baseline expression, differential expression, functional genomics, public repository, repository, bioinformatics, europe, institute">
+    <meta name="author" content="EBI Functional Genomics Team – https://www.ebi.ac.uk/people/person/christina-ernst">
+    <meta name="HandheldFriendly" content="true" />
+    <meta name="MobileOptimized" content="width" />
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="theme-color" content="#70BDBD"> <!-- Android Chrome mobile browser tab color -->
+
+    <!-- Add information on the life cycle of this page -->
+    <meta name="ebi:owner" content="Christina Ernst <cernst@ebi.ac.uk>">
+
+    <!-- If you link to any other sites frequently, consider optimising performance with a DNS prefetch -->
+    <link rel="dns-prefetch" href="https://www.ebi.ac.uk/gxa/sc">
+    <link rel="dns-prefetch" href="https://www.ebi.ac.uk/arrayexpress/">
+    <link rel="dns-prefetch" href="https://www.ebi.ac.uk/">
+    <link rel="dns-prefetch" href="https://embl.de/">
+
+    <!-- favicons generated at realfavicongenerator.net, and merged with https://github.com/ebiwd/EBI-Pattern-library/blob/gh-pages/sample-site/boilerplate/blank.html -->
+    <!-- If you have custom icon, replace these as appropriate. You can generate them at realfavicongenerator.net -->
+    <link rel="icon" type="image/x-icon" href="resources/favicons/favicon.ico" />
+    <link rel="icon" type="image/png" href="resources/favicons/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="192×192" href="resources/favicons/android-chrome-192x192.png" /> <!-- Android (192px) -->
+    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="resources/favicons/apple-icon-114x114.png" /> <!-- For iPhone 4 Retina display (114px) -->
+    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="resources/favicons/apple-icon-72x72.png" /> <!-- For iPad (72px) -->
+    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="resources/favicons/apple-icon-144x144.png" /> <!-- For iPad retina (144px) -->
+    <link rel="apple-touch-icon-precomposed" href="resources/favicons/apple-icon-57x57.png" /> <!-- For iPhone (57px) -->
+    <link rel="mask-icon" href="resources/favicons/safari-pinned-tab.svg" color="#ffffff" /> <!-- Safari icon for pinned tab -->
+    <meta name="msapplication-TileColor" content="#2b5797" /> <!-- MS Icons -->
+    <meta name="msapplication-TileImage" content="resources/favicons/mstile-144x144.png" />
+
+    <!-- CSS: implied media=all -->
+    <!-- CSS concatenated and minified via ant build script-->
+    <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/css/ebi-global.css" type="text/css" media="all" />
+    <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css" type="text/css" media="all" />
+
+    <!-- If you have a custom header image or colour -->
+    <meta name="ebi:masthead-color" content="rgb(0,124,130)" />
+    <meta name="ebi:masthead-image" content="resources/images/dots-matrix-background.png" />
+
+    <!-- you can replace this with theme-[projectname].css. See http://www.ebi.ac.uk/web/style/colour for details of how to do this -->
+    <!-- also inform ES so we can host your colour palette file -->
+    <!-- <link rel="stylesheet" href="https://dev.ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/css/theme-embl-petrol.css" type="text/css" media="all" /> -->
+    <link rel="stylesheet" href="resources/css/foundation/atlas.css" type="text/css" media="all">
+
+    <!-- Use this CSS file for any custom styling -->
+    <link rel="stylesheet" href="resources/css/foundation/theme-atlas.css" type="text/css" media="all">
+    <!-- end CSS-->
+
+</head>
+
+<body>
+<div id="skip-to">
+    <ul>
+        <li><a href="#content">Skip to main content</a></li>
+        <li><a href="#local-nav">Skip to local navigation</a></li>
+        <li><a href="#global-nav">Skip to EBI global navigation menu</a></li>
+        <li><a href="#global-nav-expanded">Skip to expanded EBI global navigation menu (includes all sub-sections)</a></li>
+    </ul>
+</div>
+
+<div th:replace="~{fragments/fragments :: global-masthead}"></div>
+<div th:replace="~{fragments/fragments :: local-masthead}"></div>
+
+<div id="content">
+    <section id="main-content-area" class="margin-top-large margin-bottom-large" role="main">
+        <div th:replace="~{${content}}"></div>
+    </section>
+    <div th:replace="~{fragments/fragments :: local-footer}"></div>
+</div>
+
+<div th:replace="~{fragments/fragments :: global-footer}"></div>
+
+<!-- jQuery -->
+<script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-migrate-1.4.1.min.js"></script>
+
+<!-- Don’t defer or async, these two need to be loaded before other bundles, which are effectively deferred -->
+<script src="resources/js/lib/babel-polyfill.min.js"></script>
+<script src="resources/js/lib/fetch-polyfill.min.js"></script>
+<script src="resources/js-bundles/vendorCommons.bundle.js"></script>
+<script src="resources/js-bundles/informationBanner.bundle.js"></script>
+
+<!-- JavaScript -->
+<script defer="defer" src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/js/script.js"></script>
+
+<!-- The Foundation theme JavaScript -->
+<script src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/libraries/foundation-6/js/foundation.js"></script>
+<script src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/js/foundationExtendEBI.js"></script>
+<script>$(document).foundation();</script>
+<script>$(document).foundationExtendEBI();</script>
+
+<link rel="stylesheet" type="text/css" href="resources/js/lib/jquery-ui-1.12.1.custom/jquery-ui.min.css">
+<link rel="stylesheet" type="text/css" href="resources/js/lib/jquery-json-tag-editor/jquery.json-tag-editor.foundation.css" media="screen">
+<!-- end CSS-->
+
+<!-- Google Analytics details -->
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-37676851-1', 'auto');
+  ga('send', 'pageview');
+  informationBanner.render({}, 'information-banner');
+</script>
+
+</body>
+</html>

--- a/app/src/main/resources/templates/thymeleaf/fragments/fragments.html
+++ b/app/src/main/resources/templates/thymeleaf/fragments/fragments.html
@@ -1,0 +1,104 @@
+<header th:fragment="global-masthead" id="masthead-black-bar" class="clearfix masthead-black-bar expanded">
+    <script>
+        // Hack that solves https://github.com/ebiwd/EBI-Framework/pull/139 (I got tired of waiting)
+        window.addEventListener('load', function(event) {
+            $('#masthead-black-bar nav')[2].className='row expanded';
+        });
+    </script>
+</header>
+
+<div th:fragment="local-masthead">
+    <div id="information-banner" style="background: #C5C5C5; font-size: large"></div>
+    <div data-sticky-container>
+        <header id="masthead" class="masthead" data-sticky data-sticky-on="large" data-top-anchor="content:top" data-btm-anchor="content:bottom">
+            <div class="masthead-inner row expanded">
+                <div class="small-12 large-8 columns">
+                    <a href="home" title="Back to Expression Atlas homepage">
+                        <div class="media-object" id="local-title">
+                            <div class="media-object-section hide-for-small-only">
+                                <img src="resources/images/expression-atlas.png" alt="Expression Atlas logo" style="height: 7em">
+                            </div>
+                            <div class="media-object-section">
+                                <h1>Expression&nbsp;Atlas</h1>
+                                <h4 class="show-for-large">Gene expression across species and biological conditions</h4>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+                <div class="small-12 large-4 columns">
+                    <div class="media-object" style="display: flex; justify-content: flex-end; align-items: center;">
+                        <div class="media-object-section">
+                            <h4 class="show-for-large">Query single cell expression</h4>
+                            <a href="/gxa/sc" title="To Single Cell Expression Atlas" class="button" style="box-shadow: 2px 2px 2px 2px rgba(0,0,0,0.5)">To Single Cell Expression Atlas <i class="icon icon-functional" data-icon=">"></i></a>
+                        </div>
+                    </div>
+                </div>
+
+                <nav>
+                    <ul id="local-nav" class="dropdown menu float-left" data-description="navigational">
+                        <li id="local-nav-home"><a href="home"><i class="icon icon-generic padding-right-medium" data-icon="H"></i>Home</a></li>
+                        <li id="local-nav-experiments"><a href="experiments"><i class="icon icon-functional padding-right-medium" data-icon="C"></i>Browse experiments</a></li>
+                        <li id="local-nav-download"><a href="download"><i class="icon icon-functional padding-right-medium" data-icon="="></i>Download</a></li>
+                        <li id="local-nav-release-notes"><a href="release-notes.html"><i class="icon icon-generic padding-right-medium" data-icon=";"></i>Release notes</a></li>
+                        <li id="local-nav-faq"><a href="FAQ.html"><i class="icon icon-generic padding-right-medium" data-icon="G"></i>FAQ</a></li>
+                        <li id="local-nav-help"><a href="help/index.html"><i class="icon icon-generic padding-right-medium" data-icon="?"></i>Help</a></li>
+                        <li id="local-nav-licence"><a href="licence.html"><i class="icon icon-common padding-right-medium" data-icon="&#xf573;"></i>Licence</a></li>
+                        <li id="local-nav-about"><a href="about.html"><i class="icon icon-generic padding-right-medium" data-icon="i"></i>About</a></li>
+                        <li id="local-nav-feedback"><a href="https://www.ebi.ac.uk/support/gxa" target="_blank" data-icon="X"><i class="icon icon-generic padding-right-medium" data-icon="s"></i>Support</a></li>
+                    </ul>
+                </nav>
+            </div>
+        </header>
+    </div>
+</div>
+
+<footer th:fragment="global-footer">
+    <div id="global-footer" class="global-footer">
+        <nav id="global-nav-expanded" class="global-nav row">
+        </nav>
+        <section id="ebi-footer-meta" class="ebi-footer-meta row">
+        </section>
+    </div>
+</footer>
+
+<footer th:fragment="local-footer" id="local-footer" class="local-footer" role="local-footer">
+    <div id="local-footer-nav-menu" class="row expanded">
+        <div class="small-12 small-centered medium-8 large-6 columns">
+            <div class="row small-up-1 medium-up-3">
+                <div class="column column-block margin-top-large margin-bottom-large text-center">
+                    <h4 style="color:white">Experiments</h4>
+                    <a href="experiments?experimentType=baseline" target="_blank">Baseline experiments</a><br/>
+                    <a href="experiments?experimentType=differential" target="_blank">Differential experiments</a>
+                </div>
+
+                <div class="column column-block margin-top-large margin-bottom-large text-center">
+                    <h4 style="color:white">Atlas</h4>
+                    <a href="release-notes.html" target="_blank">Release notes</a><br/>
+                    <a href="download.html" target="_blank">Download</a><br/>
+                    <a href="help/index.html" target="_blank">Help</a><br/>
+                    <a href="FAQ.html" target="_blank">FAQ</a><br/>
+                    <a href="about.html" target="_blank">About Atlas</a>
+                </div>
+
+                <div class="column column-block margin-top-large margin-bottom-large text-center">
+                    <h4 style="color:white">Follow us</h4>
+                    <a href="https://twitter.com/ExpressionAtlas" target="_blank">Twitter</a><br/>
+                    <a href="https://www.ebi.ac.uk/support/gxa" target="_blank">Support</a><br/>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="relationships" class="row">
+        <div id="elixir-banner"
+             data-color="none"
+             data-use-cdr-logo="false"
+             data-name="This service"
+             data-description="Expression Atlas is an ELIXIR database service"
+             data-more-information-link="https://www.elixir-europe.org/about-us/who-we-are/nodes/embl-ebi"
+             data-use-basic-styles="false">
+        </div>
+    </div>
+
+    <script defer="defer" src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/js/elixirBanner.js"></script>
+</footer>

--- a/app/src/main/resources/templates/thymeleaf/views/download.html
+++ b/app/src/main/resources/templates/thymeleaf/views/download.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html th:replace="~{fragments/base :: base('views/download/download_content') }"
+      xmlns:th="http://www.thymeleaf.org" lang="en">
+</html>

--- a/app/src/main/resources/templates/thymeleaf/views/download/download_content.html
+++ b/app/src/main/resources/templates/thymeleaf/views/download/download_content.html
@@ -1,6 +1,3 @@
-<%@ page pageEncoding="UTF-8" contentType="text/html;charset=UTF-8" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-
 <div class="row">
     <div class="12 columns">
         <h2>Download</h2>

--- a/app/src/main/webapp/WEB-INF/tiles/views.xml
+++ b/app/src/main/webapp/WEB-INF/tiles/views.xml
@@ -24,11 +24,6 @@
         <put-attribute name="content" value="/WEB-INF/jsp/tiles/views/experiments.jsp"/>
     </definition>
 
-    <definition name="download" extends="base">
-        <put-attribute name="title" value="Download &lt; "/>
-        <put-attribute name="content" value="/WEB-INF/jsp/tiles/views/download.jsp"/>
-    </definition>
-
     <definition name="baseline-landing-page" extends="base">
         <put-attribute name="title" value="Baseline experiments &lt; "/>
         <put-attribute name="content" value="/WEB-INF/jsp/tiles/views/baseline-landing-page.jsp"/>

--- a/app/src/test/java/uk/ac/ebi/atlas/download/DownloadControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/download/DownloadControllerWIT.java
@@ -3,10 +3,8 @@ package uk.ac.ebi.atlas.download;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -14,13 +12,12 @@ import org.springframework.web.context.WebApplicationContext;
 import uk.ac.ebi.atlas.configuration.TestConfig;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 
-@ExtendWith(SpringExtension.class)
 @WebAppConfiguration
-@ContextConfiguration(classes = TestConfig.class)
+@SpringJUnitConfig(classes = TestConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class DownloadControllerWIT {
 
@@ -35,25 +32,17 @@ class DownloadControllerWIT {
     }
 
     @Test
-    void downloadReturnsValidModel() throws Exception {
+    void downloadReturnsValidViewName() throws Exception {
         this.mockMvc.perform(get("/download"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("download"));
     }
 
     @Test
-    void downloadModelHaveFtpFileInfo() throws Exception {
+    void downloadModelHaveTitle() throws Exception {
         this.mockMvc.perform(get("/download"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("download"))
-                .andExpect(model().attributeExists("mainTitle"));
-    }
-
-    @Test
-    void downloadModelHaveEmptyFtpFileInfoForInvalidHost() throws Exception {
-        this.mockMvc.perform(get("/download").param("ftpHost","foo"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("download"))
-                .andExpect(model().attributeDoesNotExist("fileName", "fileSize", "fileTimestamp"));
+                .andExpect(model().attributeExists("title"));
     }
 }


### PR DESCRIPTION
This is the first PR that starts refactoring our views on the front-end and gradually replace all the JSP/Tiles technology with HTML/ThymeLeaf.
I started with an easier one: replacing `download.jsp` with `download.html`.
I also had to create the base.html and the fragments.html.
`base.html` is the base page for all our page. It inserts headers and footers as fragments from the `fragments.html` and all our pages are going to extend this page.