### PR TITLE
use expression-atlas-experiment-page 1.19.1 #273 

### DIFF
--- a/app/src/main/javascript/package-lock.json
+++ b/app/src/main/javascript/package-lock.json
@@ -4,14 +4,13 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "javascript",
       "dependencies": {
         "@ebi-gene-expression-group/anatomogram": "^2.4.0",
         "@ebi-gene-expression-group/atlas-bioentity-information": "^2.1.8",
         "@ebi-gene-expression-group/atlas-feedback-form": "^1.4.5",
         "@ebi-gene-expression-group/atlas-homepage-cards": "^2.5.8",
         "@ebi-gene-expression-group/atlas-react-fetch-loader": "^3.9.4",
-        "@ebi-gene-expression-group/expression-atlas-experiment-page": "1.19.0",
+        "@ebi-gene-expression-group/expression-atlas-experiment-page": "1.19.1",
         "@ebi-gene-expression-group/expression-atlas-heatmap-highcharts": "^5.7.1",
         "@ebi-gene-expression-group/expression-atlas-number-format": "^3.2.0",
         "@ebi-gene-expression-group/react-ebi-species": "^2.6.6",
@@ -2056,9 +2055,10 @@
       }
     },
     "node_modules/@ebi-gene-expression-group/expression-atlas-experiment-page": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@ebi-gene-expression-group/expression-atlas-experiment-page/-/expression-atlas-experiment-page-1.19.0.tgz",
-      "integrity": "sha512-wPRvdnTJ27Qn2MKL87hu/xIe/ZsArYuitRcN8wU6E65nOPKIyGkXggaGzRd0+pxIXM4sQosM3cA4HshlFMrU0Q==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@ebi-gene-expression-group/expression-atlas-experiment-page/-/expression-atlas-experiment-page-1.19.1.tgz",
+      "integrity": "sha512-K/aeYrH7dUWl7+bfObpGkMZggUkllmDrv+aMGA4eW44x1awla7le0GioFrfpTYZ1v9O6L6W9WNrBkr8L1oJ3IQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@ebi-gene-expression-group/expression-atlas-disclaimers": "^1.4.0",
         "@ebi-gene-expression-group/expression-atlas-heatmap-highcharts": "^5.7.0",
@@ -2078,6 +2078,9 @@
         "sanitize-html": "^1.20.1",
         "urijs": "^1.19.1",
         "webpack-cli": "^3.3.9"
+      },
+      "engines": {
+        "node": "14.x"
       }
     },
     "node_modules/@ebi-gene-expression-group/expression-atlas-experiment-page/node_modules/hoist-non-react-statics": {

--- a/app/src/main/javascript/package.json
+++ b/app/src/main/javascript/package.json
@@ -23,7 +23,7 @@
     "@ebi-gene-expression-group/atlas-feedback-form": "^1.4.5",
     "@ebi-gene-expression-group/atlas-homepage-cards": "^2.5.8",
     "@ebi-gene-expression-group/atlas-react-fetch-loader": "^3.9.4",
-    "@ebi-gene-expression-group/expression-atlas-experiment-page": "1.19.0",
+    "@ebi-gene-expression-group/expression-atlas-experiment-page": "1.19.1",
     "@ebi-gene-expression-group/expression-atlas-heatmap-highcharts": "^5.7.1",
     "@ebi-gene-expression-group/expression-atlas-number-format": "^3.2.0",
     "@ebi-gene-expression-group/react-ebi-species": "^2.6.6",


### PR DESCRIPTION
use expression-atlas-experiment-page 1.19.1 with sort by specificity to false 
fixes #273

- [ ] merge after publishing expression-atlas-experiment-page 1.19.1 to npmjs
