### PR TITLE
[Chore#306] Remove duplicate MIS-C (E-CURD-146) experiment link from landing page

### DIFF
--- a/app/src/main/resources/templates/thymeleaf/views/edtl-landing-page/edtl-landing-page_content.html
+++ b/app/src/main/resources/templates/thymeleaf/views/edtl-landing-page/edtl-landing-page_content.html
@@ -37,9 +37,6 @@
       <li>
         <a th:href="@{/experiments/E-CURD-146}">Diagnosis of multisystem inflammatory syndrome in children (MIS-C) by a whole-blood transcriptional signature</a>
       </li>
-      <li>
-        <a th:href="@{/experiments/E-CURD-149}">Diagnosis of multisystem inflammatory syndrome in children (MIS-C) by a whole-blood transcriptional signature - differential analysis</a>
-      </li>
     </ul>
     <h3>Differential experiments</h3>
     <ul>

--- a/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'uk.ac.ebi.ge'
-version = '37.2.10'
+version = '37.2.11'
 
 sourceCompatibility = 11
 targetCompatibility = 11


### PR DESCRIPTION
The duplicate link to the MIS-C experiment "E-CURD-149" was removed from the wrong experiment type listing.