### PR TITLE
[Chore/GXA-561] Update the homepage's publication section with citation details

### DIFF
--- a/app/src/main/resources/templates/thymeleaf/views/home/publications.html
+++ b/app/src/main/resources/templates/thymeleaf/views/home/publications.html
@@ -1,11 +1,33 @@
 <div th:fragment="home-publications">
     <div id="publication-list" class="callout" data-equalizer-watch>
-        <h4>Publications</h4>
+        <h4>How to cite Expression Atlas</h4>
+        <h5>
+            If you’re using Expression Atlas in your research, please consider citing our most recent update in
+            <i>Nucleic Acids Research:</i>
+        </h5>
+
+        <a href="https://academic.oup.com/nar/advance-article/doi/10.1093/nar/gkaf1238/8376685" target="_blank">
+            <div class="media-object">
+                <div class="media-object-section middle">
+                    <h3 class="icon icon-conceptual" data-icon="l"></h3>
+                </div>
+                <div class="media-object-section middle">
+                    <p>
+                        <strong>Expression Atlas in 2026:</strong> enabling FAIR and open expression data through community collaboration and integration<br>
+                        <em>Nucleic Acids Research</em>, 10 December 2025.
+                    </p>
+                </div>
+            </div>
+        </a>
+
+        <h5>
+            If you would like to reference specific historical updates or methodology, you can also cite:
+        </h5>
 
         <a href="https://academic.oup.com/nar/article/52/D1/D107/7442051" target="_blank">
             <div class="media-object">
                 <div class="media-object-section middle">
-                    <h3 class="icon icon-conceptual" data-icon="l" />
+                    <h3 class="icon icon-conceptual" data-icon="l"></h3>
                 </div>
                 <div class="media-object-section middle">
                     <p>
@@ -19,7 +41,7 @@
         <a href="https://academic.oup.com/nar/article/50/D1/D129/6438036" target="_blank">
             <div class="media-object">
                 <div class="media-object-section middle">
-                    <h3 class="icon icon-conceptual" data-icon="l" />
+                    <h3 class="icon icon-conceptual" data-icon="l"></h3>
                 </div>
                 <div class="media-object-section middle">
                     <p>
@@ -33,7 +55,7 @@
         <a href="http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0107026" target="_blank">
             <div class="media-object">
                 <div class="media-object-section middle">
-                    <h3 class="icon icon-conceptual" data-icon="l" />
+                    <h3 class="icon icon-conceptual" data-icon="l"></h3>
                 </div>
                 <div class="media-object-section middle">
                     <p>

--- a/app/src/main/resources/templates/thymeleaf/views/licence/licence_content.html
+++ b/app/src/main/resources/templates/thymeleaf/views/licence/licence_content.html
@@ -8,16 +8,15 @@
             that anyone is free to copy, reuse, display and distribute the images and information on our database, provided you give us
             credit by citing:
         </p>
-        <cite>
-            <p class="icon icon-conceptual" data-icon="l">
-                <a href="https://academic.oup.com/nar/article/50/D1/D129/6438036">Expression Atlas update: gene and protein expression in multiple species</a>
-                (<i>Nucleic Acids Research</i>, 24 November 2021).
-            </p>
-        </cite>
-
+        <p class="icon icon-conceptual" data-icon="l">
+            <a href="https://academic.oup.com/nar/advance-article/doi/10.1093/nar/gkaf1238/8376685">
+                <strong>Expression Atlas in 2026:</strong> enabling FAIR and open expression data through community collaboration and integration<br>
+            </a>
+            (<i>Nucleic Acids Research</i>, 10 December 2025).
+        </p>
         <p>
             The Expression Atlas source code is available through our <a href="https://github.com/ebi-gene-expression-group/atlas-web-bulk">GitHub Repository</a>.
-            It is also copyrighted with an Apache licence attached, <strong>Copyright 2008-2020 Gene Expression Team, EMBL-European
+            It is also copyrighted with an Apache licence attached, <strong>Copyright 2008-2026 Functional Genomics Team, EMBL-European
             Bioinformatics Institute</strong>. This means that you can freely use, modify, distribute and/or commercially use the software
             provided you include copyright and licence, state changes and include this notice. A copy of the licence can be obtained here:
             <a href="http://www.apache.org/licenses/LICENSE-2.0"> Apache License, Version 2.0</a>.

--- a/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'uk.ac.ebi.ge'
-version = '37.5.0'
+version = '37.6.0'
 
 sourceCompatibility = 11
 targetCompatibility = 11


### PR DESCRIPTION
Renamed the publications header and added detailed citation guidance, including links to recent and historical references in the template. 
Incremented the project version from 37.5.0 to 37.6.0 to reflect these content changes.